### PR TITLE
Feat multiple crypto pwds

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/crypto/IAS4CryptoFactory.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/crypto/IAS4CryptoFactory.java
@@ -77,4 +77,23 @@ public interface IAS4CryptoFactory
    */
   @Nullable
   KeyStore getTrustStore ();
+  
+  /**
+   * Returns the password for the key represented by the provided alias.
+   * 
+   * @param keyAlias The alias of the key whose password is to be retrieved.
+   * @return The password for the key represented by the provided by the alias or
+   *         <code>null</code> if the factory doesn't have a password for the key.
+   */
+  @Nullable
+  default String getKeyPassword(String keyAlias)
+  {
+	// Use case insensitive compare, depends on the keystore type
+	if (this.getKeyAlias().equalsIgnoreCase(keyAlias))
+	{
+	  return this.getKeyPassword();
+	}
+	  
+	return null;
+  }
 }

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
@@ -84,11 +84,11 @@ public final class Phase4KeyStoreCallbackHandler implements CallbackHandler
       {
         final WSPasswordCallback aPasswordCallback = (WSPasswordCallback) aCallback;
 
-        // Use case insensitive compare, depends on the keystore type
-        if (m_aCryptoFactory.getKeyAlias ().equalsIgnoreCase (aPasswordCallback.getIdentifier ()))
+        // Obtain the password from the crypto factory
+        String aKeyPassword = m_aCryptoFactory.getKeyPassword (aPasswordCallback.getIdentifier ());
+        if (aKeyPassword != null)
         {
-          aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
-          if (LOGGER.isInfoEnabled ())
+        	aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
             LOGGER.info ("Found keystore password for alias '" +
                          aPasswordCallback.getIdentifier () +
                          "' and usage " +
@@ -96,11 +96,10 @@ public final class Phase4KeyStoreCallbackHandler implements CallbackHandler
         }
         else
         {
-          if (LOGGER.isWarnEnabled ())
-            LOGGER.warn ("Found unsupported keystore alias '" +
-                         aPasswordCallback.getIdentifier () +
-                         "' and usage " +
-                         _getUsage (aPasswordCallback.getUsage ()));
+        	LOGGER.warn ("Found unsupported keystore alias '" +
+                    aPasswordCallback.getIdentifier () +
+                    "' and usage " +
+                    _getUsage (aPasswordCallback.getUsage ()));
         }
       }
       else

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
@@ -88,17 +88,17 @@ public final class Phase4KeyStoreCallbackHandler implements CallbackHandler
         String aKeyPassword = m_aCryptoFactory.getKeyPassword (aPasswordCallback.getIdentifier ());
         if (aKeyPassword != null)
         {
-        	aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
-        	if (LOGGER.isInfoEnabled ())
-              LOGGER.info ("Found keystore password for alias '" +
+          aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
+          if (LOGGER.isInfoEnabled ())
+            LOGGER.info ("Found keystore password for alias '" +
                            aPasswordCallback.getIdentifier () +
                            "' and usage " +
                            _getUsage (aPasswordCallback.getUsage ()));
         }
         else
         {
-        	if (LOGGER.isWarnEnabled ())
-        	  LOGGER.warn ("Found unsupported keystore alias '" +
+          if (LOGGER.isWarnEnabled ())
+            LOGGER.warn ("Found unsupported keystore alias '" +
                            aPasswordCallback.getIdentifier () +
                            "' and usage " +
                            _getUsage (aPasswordCallback.getUsage ()));

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
@@ -88,7 +88,7 @@ public final class Phase4KeyStoreCallbackHandler implements CallbackHandler
         String aKeyPassword = m_aCryptoFactory.getKeyPassword (aPasswordCallback.getIdentifier ());
         if (aKeyPassword != null)
         {
-          aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
+          aPasswordCallback.setPassword (aKeyPassword);
           if (LOGGER.isInfoEnabled ())
             LOGGER.info ("Found keystore password for alias '" +
                          aPasswordCallback.getIdentifier () +

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
@@ -89,17 +89,19 @@ public final class Phase4KeyStoreCallbackHandler implements CallbackHandler
         if (aKeyPassword != null)
         {
         	aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
-            LOGGER.info ("Found keystore password for alias '" +
-                         aPasswordCallback.getIdentifier () +
-                         "' and usage " +
-                         _getUsage (aPasswordCallback.getUsage ()));
+        	if (LOGGER.isInfoEnabled ())
+              LOGGER.info ("Found keystore password for alias '" +
+                           aPasswordCallback.getIdentifier () +
+                           "' and usage " +
+                           _getUsage (aPasswordCallback.getUsage ()));
         }
         else
         {
-        	LOGGER.warn ("Found unsupported keystore alias '" +
-                    aPasswordCallback.getIdentifier () +
-                    "' and usage " +
-                    _getUsage (aPasswordCallback.getUsage ()));
+        	if (LOGGER.isWarnEnabled ())
+        	  LOGGER.warn ("Found unsupported keystore alias '" +
+                           aPasswordCallback.getIdentifier () +
+                           "' and usage " +
+                           _getUsage (aPasswordCallback.getUsage ()));
         }
       }
       else

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/soap/Phase4KeyStoreCallbackHandler.java
@@ -91,17 +91,17 @@ public final class Phase4KeyStoreCallbackHandler implements CallbackHandler
           aPasswordCallback.setPassword (m_aCryptoFactory.getKeyPassword ());
           if (LOGGER.isInfoEnabled ())
             LOGGER.info ("Found keystore password for alias '" +
-                           aPasswordCallback.getIdentifier () +
-                           "' and usage " +
-                           _getUsage (aPasswordCallback.getUsage ()));
+                         aPasswordCallback.getIdentifier () +
+                         "' and usage " +
+                         _getUsage (aPasswordCallback.getUsage ()));
         }
         else
         {
           if (LOGGER.isWarnEnabled ())
             LOGGER.warn ("Found unsupported keystore alias '" +
-                           aPasswordCallback.getIdentifier () +
-                           "' and usage " +
-                           _getUsage (aPasswordCallback.getUsage ()));
+                         aPasswordCallback.getIdentifier () +
+                         "' and usage " +
+                         _getUsage (aPasswordCallback.getUsage ()));
         }
       }
       else


### PR DESCRIPTION
## Change Description
This change gives the crypto factory the ability to manage multiple keys. The example use case would be separate Signature and Decryption Keys on Inbound. WSS4j attempts to find the key using the name of the key that encrypted the data and Phase4 uses the primary key of the crypto factory to sign the receipt signal message, however, these keys need to be the same due to the password handling logic in [Phase4KeyStoreCallbackHandler.java](https://github.com/phax/phase4/compare/master...jsmithers:phase4:feat-multiple-crypto-pwds?expand=1#diff-8ac4ea26a688ce9dd6909f946ac462762c5d177b09bc26ccc261e67cde34d6f2).

This change allows implementers to provide separate keys for both operations, by simply overriding the `getKeyPassword (String)` method in the `IAS4CryptoFactory`. The existing logic is maintained through the default implementation in the interface. 

**Example:**
```Java
public class MyCryptoFactory implements IAS4CryptoFactory {

  /* Existing Crypto Getters */

  public String getKeyPassword (String keyAlias) {
    String password = super.getKeyPassword (keyAlias);
    if (password == null) {
      // Lookup the other key password, possibly in a Map
    }

    return password;
  }
```