### PR TITLE
Initialize `ETriState` member variables as `UNDEFINED`

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/model/pmode/PModeReceptionAwareness.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/pmode/PModeReceptionAwareness.java
@@ -40,11 +40,11 @@ public class PModeReceptionAwareness implements Serializable
   public static final long DEFAULT_RETRY_INTERVAL_MS = 10 * CGlobal.MILLISECONDS_PER_SECOND;
   public static final boolean DEFAULT_DUPLICATE_DETECTION = true;
 
-  private ETriState m_eReceptionAwareness;
-  private ETriState m_eRetry;
+  private ETriState m_eReceptionAwareness = ETriState.UNDEFINED;
+  private ETriState m_eRetry = ETriState.UNDEFINED;
   private int m_nMaxRetries;
   private long m_nRetryIntervalMS;
-  private ETriState m_eDuplicateDetection;
+  private ETriState m_eDuplicateDetection = ETriState.UNDEFINED;
 
   public PModeReceptionAwareness (@Nonnull final ETriState eReceptionAwareness,
                                   @Nonnull final ETriState eRetry,

--- a/phase4-lib/src/main/java/com/helger/phase4/model/pmode/leg/PModeLegErrorHandling.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/pmode/leg/PModeLegErrorHandling.java
@@ -66,7 +66,7 @@ public class PModeLegErrorHandling implements Serializable
    * receiving a message in error are sent over the back-channel of the
    * underlying protocol associated with the message in error, or not.
    */
-  private ETriState m_eReportAsResponse;
+  private ETriState m_eReportAsResponse = ETriState.UNDEFINED;
 
   /**
    * This Boolean parameter indicates whether (if "true") the Consumer
@@ -74,7 +74,7 @@ public class PModeLegErrorHandling implements Serializable
    * notified when an error occurs in the Receiving MSH, during processing of
    * the received User message.
    */
-  private ETriState m_eReportProcessErrorNotifyConsumer;
+  private ETriState m_eReportProcessErrorNotifyConsumer = ETriState.UNDEFINED;
 
   /**
    * This Boolean parameter indicates whether (if "true") the Producer
@@ -82,7 +82,7 @@ public class PModeLegErrorHandling implements Serializable
    * notified when an error occurs in the Sending MSH, during processing of the
    * User Message to be sent.
    */
-  private ETriState m_eReportProcessErrorNotifyProducer;
+  private ETriState m_eReportProcessErrorNotifyProducer = ETriState.UNDEFINED;
 
   /**
    * This Boolean parameter indicates whether (if "true") the Producer
@@ -95,7 +95,7 @@ public class PModeLegErrorHandling implements Serializable
    * of all cases of non-delivery that occur after the message has been received
    * by the Receiving MSH.
    */
-  private ETriState m_eReportDeliveryFailuresNotifyProducer;
+  private ETriState m_eReportDeliveryFailuresNotifyProducer = ETriState.UNDEFINED;
 
   public PModeLegErrorHandling ()
   {}


### PR DESCRIPTION
Initializing `ETriState` member variables by default to undefined makes the objects behave consistently.

Before `new PModeLegSecurity().isPModeAuthorizeDefined() == false` while `new PModeLegErrorHandling().isReportAsResponseDefined()` would throw a `NullPointerException`.

With this change, every `ETriState` should be properly initialized (I used `grep -r -F 'ETriState m_' src` to find all occurrences).