### PR TITLE
BDEW Profile and Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ phase4-data/
 phase4-dumps/
 phase4-test-data/
 incoming/
+
+.idea

--- a/phase4-bdew-client/findbugs-exclude.xml
+++ b/phase4-bdew-client/findbugs-exclude.xml
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+    gregor[dot]scholtysik[at]soptim[dot]de
+
+    Copyright (C) 2021 Philip Helger (www.helger.com)
+    philip[at]helger[dot]com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<FindBugsFilter>
+  <!-- Docs: http://findbugs.sourceforge.net/manual/filter.html -->
+</FindBugsFilter>

--- a/phase4-bdew-client/pom.xml
+++ b/phase4-bdew-client/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+    gregor[dot]scholtysik[at]soptim[dot]de
+
+    Copyright (C) 2021 Philip Helger (www.helger.com)
+    philip[at]helger[dot]com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.helger.phase4</groupId>
+        <artifactId>phase4-parent-pom</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>phase4-bdew-client</artifactId>
+    <packaging>bundle</packaging>
+    <name>phase4-bdew-client</name>
+    <description>BDEW AS4 client for outgoing transmissions</description>
+    <url>https://github.com/phax/phase4/phase4-bdew-client</url>
+    <inceptionYear>2023</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>gregorscholtysik</id>
+            <name>Gregor Scholtysik</name>
+            <email>gregor.scholtysik@soptim.de</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.helger.phase4</groupId>
+            <artifactId>phase4-lib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.helger.phase4</groupId>
+            <artifactId>phase4-profile-bdew</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Automatic-Module-Name>com.helger.phase4.bdew</Automatic-Module-Name>
+                        <Export-Package>com.helger.phase4.bdew.*</Export-Package>
+                        <Import-Package>!javax.annotation.*,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/phase4-bdew-client/src/etc/javadoc.css
+++ b/phase4-bdew-client/src/etc/javadoc.css
@@ -1,0 +1,586 @@
+/**
+ * Copyright (C) 2015-2023 Pavel Rotek
+ * pavel[dot]rotek[at]gmail[dot]com
+ *
+ * Copyright (C) 2021 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * based on phloc javadoc CSS.
+ * (c) 2011-2014 phloc systems.
+ * Derived from the original javadoc CSS from Sun JDK
+ */
+ 
+body {
+	background-color: #FFFFFF;
+	color: #353833;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 76%;
+	margin: 0;
+}
+
+a:link,a:visited {
+	color: #880000;
+	text-decoration: none;
+}
+
+a:hover,a:focus {
+	color: #BB2222;
+	text-decoration: none;
+}
+
+a:active {
+	color: #4C6B87;
+	text-decoration: none;
+}
+
+a[name] {
+	color: #353833;
+}
+
+a[name]:hover {
+	color: #353833;
+	text-decoration: none;
+}
+
+pre {
+	font-size: 1.3em;
+}
+
+h1 {
+	font-size: 1.8em;
+}
+
+h2 {
+	font-size: 1.5em;
+}
+
+h3 {
+	font-size: 1.4em;
+}
+
+h4 {
+	font-size: 1.3em;
+}
+
+h5 {
+	font-size: 1.2em;
+}
+
+h6 {
+	font-size: 1.1em;
+}
+
+ul {
+	list-style-type: disc;
+}
+
+code,tt {
+	font-size: 1.2em;
+}
+
+dt code {
+	font-size: 1.2em;
+}
+
+table tr td dt code {
+	font-size: 1.2em;
+	vertical-align: top;
+}
+
+sup {
+	font-size: 0.6em;
+}
+
+.clear {
+	clear: both;
+	height: 0;
+	overflow: hidden;
+}
+
+.aboutLanguage {
+	float: right;
+	font-size: 0.8em;
+	margin-top: -7px;
+	padding: 0 21px;
+	z-index: 200;
+}
+
+.legalCopy {
+	margin-left: 0.5em;
+}
+
+.bar a,.bar a:link,.bar a:visited,.bar a:active {
+	color: #FFFFFF;
+	text-decoration: none;
+}
+
+.bar a:hover,.bar a:focus {
+	color: #BB7A2A;
+}
+
+.tab {
+	background-color: #0066FF;
+	background-image: url("resources/titlebar.gif");
+	background-position: left top;
+	background-repeat: no-repeat;
+	color: #FFFFFF;
+	font-weight: bold;
+	padding: 8px;
+	width: 5em;
+}
+
+.bar {
+	background-image: url("resources/background.gif");
+	background-repeat: repeat-x;
+	color: #FFFFFF;
+	font-size: 1em;
+	height: auto;
+	margin: 0;
+	padding: 0.8em 0.5em 0.4em 0.8em;
+}
+
+.topNav {
+	background-image: url("resources/background.gif");
+	background-repeat: repeat-x;
+	clear: right;
+	color: #FFFFFF;
+	float: left;
+	height: 2.8em;
+	overflow: hidden;
+	padding: 10px 0 0;
+	width: 100%;
+}
+
+.bottomNav {
+	background-image: url("resources/background.gif");
+	background-repeat: repeat-x;
+	clear: right;
+	color: #FFFFFF;
+	float: left;
+	height: 2.8em;
+	margin-top: 10px;
+	overflow: hidden;
+	padding: 10px 0 0;
+	width: 100%;
+}
+
+.subNav {
+	background-color: #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	float: left;
+	overflow: hidden;
+	width: 100%;
+}
+
+.subNav div {
+	clear: left;
+	float: left;
+	padding: 0 0 5px 6px;
+}
+
+ul.navList,ul.subNavList {
+	float: left;
+	margin: 0 25px 0 0;
+	padding: 0;
+}
+
+ul.navList li {
+	float: left;
+	list-style: none outside none;
+	padding: 3px 6px;
+}
+
+ul.subNavList li {
+	float: left;
+	font-size: 90%;
+	list-style: none outside none;
+}
+
+.topNav a:link,.topNav a:active,.topNav a:visited,.bottomNav a:link,.bottomNav a:active,.bottomNav a:visited
+	{
+	color: #FFFFFF;
+	text-decoration: none;
+}
+
+.topNav a:hover,.bottomNav a:hover {
+	color: #BB7A2A;
+	text-decoration: none;
+}
+
+.navBarCell1Rev {
+	background-color: #A88834;
+	background-image: url("resources/tab.gif");
+	border: 1px solid #C9AA44;
+	color: #FFFFFF;
+	margin: auto 5px;
+}
+
+.header,.footer {
+	clear: both;
+	margin: 0 20px;
+	padding: 5px 0 0;
+}
+
+.indexHeader {
+	margin: 10px;
+	position: relative;
+}
+
+.indexHeader h1 {
+	font-size: 1.3em;
+}
+
+.title {
+	color: #880000;
+	margin: 10px 0;
+}
+
+.subTitle {
+	margin: 5px 0 0;
+}
+
+.header ul {
+	margin: 0 0 25px;
+	padding: 0;
+}
+
+.footer ul {
+	margin: 20px 0 5px;
+}
+
+.header ul li,.footer ul li {
+	font-size: 1.2em;
+	list-style: none outside none;
+}
+
+div.details ul.blockList ul.blockList ul.blockList li.blockList h4,div.details ul.blockList ul.blockList ul.blockListLast li.blockList h4
+	{
+	background-color: #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	border-top: 1px solid #9EADC0;
+	margin: 0 0 6px -8px;
+	padding: 2px 5px;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList h3 {
+	background-color: #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	border-top: 1px solid #9EADC0;
+	margin: 0 0 6px -8px;
+	padding: 2px 5px;
+}
+
+ul.blockList ul.blockList li.blockList h3 {
+	margin: 15px 0;
+	padding: 0;
+}
+
+ul.blockList li.blockList h2 {
+	padding: 0 0 20px;
+}
+
+.contentContainer,.sourceContainer,.classUseContainer,.serializedFormContainer,.constantValuesContainer
+	{
+	clear: both;
+	padding: 10px 20px;
+	position: relative;
+}
+
+.indexContainer {
+	font-size: 1em;
+	margin: 10px;
+	position: relative;
+}
+
+.indexContainer h2 {
+	font-size: 1.1em;
+	padding: 0 0 3px;
+}
+
+.indexContainer ul {
+	margin: 0;
+	padding: 0;
+}
+
+.indexContainer ul li {
+	list-style: none outside none;
+}
+
+.contentContainer .description dl dt,.contentContainer .details dl dt,.serializedFormContainer dl dt
+	{
+	color: #4E4E4E;
+	font-size: 1.1em;
+	font-weight: bold;
+	margin: 10px 0 0;
+}
+
+.contentContainer .description dl dd,.contentContainer .details dl dd,.serializedFormContainer dl dd
+	{
+	margin: 10px 0 10px 20px;
+}
+
+.serializedFormContainer dl.nameValue dt {
+	display: inline;
+	font-size: 1.1em;
+	font-weight: bold;
+	margin-left: 1px;
+}
+
+.serializedFormContainer dl.nameValue dd {
+	display: inline;
+	font-size: 1.1em;
+}
+
+ul.horizontal li {
+	display: inline;
+	font-size: 0.9em;
+}
+
+ul.inheritance {
+	margin: 0;
+	padding: 0;
+}
+
+ul.inheritance li {
+	display: inline;
+	list-style: none outside none;
+}
+
+ul.inheritance li ul.inheritance {
+	margin-left: 15px;
+	padding-left: 15px;
+	padding-top: 1px;
+}
+
+ul.blockList,ul.blockListLast {
+	margin: 10px 0;
+	padding: 0;
+}
+
+ul.blockList li.blockList,ul.blockListLast li.blockList {
+	list-style: none outside none;
+	margin-bottom: 25px;
+}
+
+ul.blockList ul.blockList li.blockList,ul.blockList ul.blockListLast li.blockList
+	{
+	background-color: #F9F9F9;
+	border: 1px solid #9EADC0;
+	padding: 0 20px 5px 10px;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList,ul.blockList ul.blockList ul.blockListLast li.blockList
+	{
+	-moz-border-bottom-colors: none;
+	-moz-border-left-colors: none;
+	-moz-border-right-colors: none;
+	-moz-border-top-colors: none;
+	background-color: #FFFFFF;
+	border-color: currentColor #9EADC0 #9EADC0;
+	border-image: none;
+	border-right: 1px solid #9EADC0;
+	border-style: none solid solid;
+	border-width: medium 1px 1px;
+	padding: 0 0 5px 8px;
+}
+
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockList {
+	-moz-border-bottom-colors: none;
+	-moz-border-left-colors: none;
+	-moz-border-right-colors: none;
+	-moz-border-top-colors: none;
+	border-color: currentColor currentColor #9EADC0;
+	border-image: none;
+	border-style: none none solid;
+	border-width: medium medium 1px;
+	margin-left: 0;
+	padding-bottom: 15px;
+	padding-left: 0;
+}
+
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockListLast {
+	border-bottom: medium none;
+	list-style: none outside none;
+	padding-bottom: 0;
+}
+
+table tr td dl,table tr td dl dt,table tr td dl dd {
+	margin-bottom: 1px;
+	margin-top: 0;
+}
+
+.contentContainer table,.classUseContainer table,.constantValuesContainer table
+	{
+	border-bottom: 1px solid #9EADC0;
+	width: 100%;
+}
+
+.contentContainer ul li table,.classUseContainer ul li table,.constantValuesContainer ul li table
+	{
+	width: 100%;
+}
+
+.contentContainer .description table,.contentContainer .details table {
+	border-bottom: medium none;
+}
+
+.contentContainer ul li table th.colOne,.contentContainer ul li table th.colFirst,.contentContainer ul li table th.colLast,.classUseContainer ul li table th,.constantValuesContainer ul li table th,.contentContainer ul li table td.colOne,.contentContainer ul li table td.colFirst,.contentContainer ul li table td.colLast,.classUseContainer ul li table td,.constantValuesContainer ul li table td
+	{
+	padding-right: 20px;
+	vertical-align: top;
+}
+
+.contentContainer ul li table th.colLast,.classUseContainer ul li table th.colLast,.constantValuesContainer ul li table th.colLast,.contentContainer ul li table td.colLast,.classUseContainer ul li table td.colLast,.constantValuesContainer ul li table td.colLast,.contentContainer ul li table th.colOne,.classUseContainer ul li table th.colOne,.contentContainer ul li table td.colOne,.classUseContainer ul li table td.colOne
+	{
+	padding-right: 3px;
+}
+
+.overviewSummary caption,.packageSummary caption,.contentContainer ul.blockList li.blockList caption,.summary caption,.classUseContainer caption,.constantValuesContainer caption
+	{
+	background-repeat: no-repeat;
+	clear: none;
+	color: #FFFFFF;
+	font-weight: bold;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+	position: relative;
+	text-align: left;
+}
+
+caption a:link,caption a:hover,caption a:active,caption a:visited {
+	color: #FFFFFF;
+}
+
+.overviewSummary caption span,.packageSummary caption span,.contentContainer ul.blockList li.blockList caption span,.summary caption span,.classUseContainer caption span,.constantValuesContainer caption span
+	{
+	background-image: url("resources/titlebar.gif");
+	display: block;
+	float: left;
+	height: 18px;
+	padding-left: 8px;
+	padding-top: 8px;
+	white-space: nowrap;
+}
+
+.overviewSummary .tabEnd,.packageSummary .tabEnd,.contentContainer ul.blockList li.blockList .tabEnd,.summary .tabEnd,.classUseContainer .tabEnd,.constantValuesContainer .tabEnd
+	{
+	background-image: url("resources/titlebar_end.gif");
+	background-position: right top;
+	background-repeat: no-repeat;
+	float: left;
+	position: relative;
+	width: 10px;
+}
+
+ul.blockList ul.blockList li.blockList table {
+	margin: 0 0 12px;
+	width: 100%;
+}
+
+.tableSubHeadingColor {
+	background-color: #EEEEFF;
+}
+
+.altColor {
+	background-color: #EEEEEF;
+}
+
+.rowColor {
+	background-color: #FFFFFF;
+}
+
+.overviewSummary td,.packageSummary td,.contentContainer ul.blockList li.blockList td,.summary td,.classUseContainer td,.constantValuesContainer td
+	{
+	padding: 3px 3px 3px 7px;
+	text-align: left;
+}
+
+th.colFirst,th.colLast,th.colOne,.constantValuesContainer th {
+	background: none repeat scroll 0 0 #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	border-top: 1px solid #9EADC0;
+	padding: 3px 3px 3px 7px;
+	text-align: left;
+}
+
+td.colOne a:link,td.colOne a:active,td.colOne a:visited,td.colOne a:hover,td.colFirst a:link,td.colFirst a:active,td.colFirst a:visited,td.colFirst a:hover,td.colLast a:link,td.colLast a:active,td.colLast a:visited,td.colLast a:hover,.constantValuesContainer td a:link,.constantValuesContainer td a:active,.constantValuesContainer td a:visited,.constantValuesContainer td a:hover
+	{
+	font-weight: bold;
+}
+
+td.colFirst,th.colFirst {
+	border-left: 1px solid #9EADC0;
+	white-space: nowrap;
+}
+
+td.colLast,th.colLast {
+	border-right: 1px solid #9EADC0;
+}
+
+td.colOne,th.colOne {
+	border-left: 1px solid #9EADC0;
+	border-right: 1px solid #9EADC0;
+}
+
+table.overviewSummary {
+	margin-left: 0;
+	padding: 0;
+}
+
+table.overviewSummary td.colFirst,table.overviewSummary th.colFirst,table.overviewSummary td.colOne,table.overviewSummary th.colOne
+	{
+	vertical-align: middle;
+	width: 25%;
+}
+
+table.packageSummary td.colFirst,table.overviewSummary th.colFirst {
+	vertical-align: middle;
+	width: 25%;
+}
+
+.description pre {
+	margin-top: 0;
+}
+
+.deprecatedContent {
+	margin: 0;
+	padding: 10px 0;
+}
+
+.docSummary {
+	padding: 0;
+}
+
+.sourceLineNo {
+	color: #008000;
+	padding: 0 30px 0 0;
+}
+
+h1.hidden {
+	font-size: 0.9em;
+	overflow: hidden;
+	visibility: hidden;
+}
+
+.block {
+	display: block;
+	margin: 3px 0 0;
+}
+
+.strong {
+	font-weight: bold;
+}

--- a/phase4-bdew-client/src/etc/license-template.txt
+++ b/phase4-bdew-client/src/etc/license-template.txt
@@ -1,0 +1,17 @@
+Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+gregor[dot]scholtysik[at]soptim[dot]de
+
+Copyright (C) 2021 Philip Helger (www.helger.com)
+philip[at]helger[dot]com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWException.java
+++ b/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.bdew;
+
+import com.helger.phase4.util.Phase4Exception;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Generic exception to be thrown from the phase4 BDEW sender.
+ *
+ * @author Gregor Scholtysik
+ */
+public class Phase4BDEWException extends Phase4Exception
+{
+  /**
+   * @param sMessage
+   *        Error message
+   */
+  public Phase4BDEWException(@Nonnull final String sMessage)
+  {
+    super (sMessage);
+  }
+
+  /**
+   * @param aCause
+   *        Optional causing exception
+   */
+  public Phase4BDEWException(@Nullable final Throwable aCause)
+  {
+    super (aCause);
+  }
+
+  /**
+   * @param sMessage
+   *        Error message
+   * @param aCause
+   *        Optional causing exception
+   */
+  public Phase4BDEWException(@Nonnull final String sMessage, @Nullable final Throwable aCause)
+  {
+    super (sMessage, aCause);
+  }
+}

--- a/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWHttpClientSettings.java
+++ b/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWHttpClientSettings.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.bdew;
+
+import com.helger.commons.ws.TrustManagerTrustAll;
+import com.helger.http.tls.ETLSVersion;
+import com.helger.httpclient.HttpClientSettings;
+import com.helger.phase4.CAS4;
+import com.helger.phase4.CAS4Version;
+import org.apache.hc.core5.util.Timeout;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import java.security.GeneralSecurityException;
+
+/**
+ * Special {@link HttpClientSettings} with better defaults for BDEW.
+ *
+ * @author Gregor Scholtysik
+ */
+public class Phase4BDEWHttpClientSettings extends HttpClientSettings
+{
+  public static final Timeout DEFAULT_BDEW_CONNECTION_REQUEST_TIMEOUT = Timeout.ofSeconds (1);
+  public static final Timeout DEFAULT_BDEW_CONNECT_TIMEOUT = Timeout.ofSeconds (5);
+  public static final Timeout DEFAULT_BDEW_RESPONSE_TIMEOUT = Timeout.ofSeconds (100);
+
+  public Phase4BDEWHttpClientSettings() throws GeneralSecurityException
+  {
+    // BDEW recommends at least TLS v1.2 [TR02102-2]
+    final SSLContext aSSLContext = SSLContext.getInstance (ETLSVersion.TLS_12.getID ());
+    // But we're basically trusting all hosts - the exact list is hard to
+    // determine
+    aSSLContext.init (null, new TrustManager [] { new TrustManagerTrustAll (false) }, null);
+    setSSLContext (aSSLContext);
+
+    setConnectionRequestTimeout (DEFAULT_BDEW_CONNECTION_REQUEST_TIMEOUT);
+    setConnectTimeout (DEFAULT_BDEW_CONNECT_TIMEOUT);
+    setResponseTimeout (DEFAULT_BDEW_RESPONSE_TIMEOUT);
+
+    // Set an explicit user agent
+    setUserAgent (CAS4.LIB_NAME + "/" + CAS4Version.BUILD_VERSION + " " + CAS4.LIB_URL);
+  }
+}

--- a/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWSender.java
+++ b/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWSender.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.bdew;
+
+import com.helger.phase4.attachment.AS4OutgoingAttachment;
+import com.helger.phase4.attachment.WSS4JAttachment;
+import com.helger.phase4.client.AS4ClientUserMessage;
+import com.helger.phase4.crypto.ECryptoKeyEncryptionAlgorithm;
+import com.helger.phase4.crypto.ECryptoKeyIdentifierType;
+import com.helger.phase4.sender.AS4BidirectionalClientHelper;
+import com.helger.phase4.sender.AbstractAS4UserMessageBuilder;
+import com.helger.phase4.util.AS4ResourceHelper;
+import com.helger.phase4.util.Phase4Exception;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * This class contains all the specifics to send AS4 messages with the BDEW
+ * profile. See <code>sendAS4Message</code> as the main method to trigger the
+ * sending, with all potential customization.
+ *
+ * @author Gregor Scholtysik
+ */
+@Immutable
+public final class Phase4BDEWSender
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (Phase4BDEWSender.class);
+
+  private Phase4BDEWSender()
+  {}
+
+  /**
+   * @return Create a new Builder for AS4 messages if the payload is present.
+   *         Never <code>null</code>.
+   */
+  @Nonnull
+  public static BDEWUserMessageBuilder builder ()
+  {
+    return new BDEWUserMessageBuilder();
+  }
+
+  /**
+   * Abstract BDEW UserMessage builder class with sanity methods
+   *
+   * @author Philip Helger
+   * @param <IMPLTYPE>
+   *        The implementation type
+   */
+  public abstract static class AbstractBDEWUserMessageBuilder<IMPLTYPE extends AbstractBDEWUserMessageBuilder<IMPLTYPE>>
+                                                                extends
+                                                                AbstractAS4UserMessageBuilder <IMPLTYPE>
+  {
+    public static final ECryptoKeyIdentifierType DEFAULT_KEY_IDENTIFIER_TYPE = ECryptoKeyIdentifierType.BST_DIRECT_REFERENCE;
+
+    private ECryptoKeyIdentifierType m_eSigningKeyIdentifierType;
+    private ECryptoKeyIdentifierType m_eEncryptionKeyIdentifierType;
+    private AS4OutgoingAttachment m_aPayload;
+    private BDEWPayloadParams m_aPayloadParams;
+
+    protected AbstractBDEWUserMessageBuilder()
+    {
+      // Override default values
+      try
+      {
+        httpClientFactory (new Phase4BDEWHttpClientSettings ());
+        setSigningKeyIdentifierType (DEFAULT_KEY_IDENTIFIER_TYPE);
+        encryptionKeyIdentifierType (DEFAULT_KEY_IDENTIFIER_TYPE);
+      }
+      catch (final Exception ex)
+      {
+        throw new IllegalStateException ("Failed to init AS4 Client builder", ex);
+      }
+    }
+
+    /**
+     * Encryption Key Identifier Type.
+     *
+     * @param eEncryptionKeyIdentifierType
+     *        {@link ECryptoKeyIdentifierType}. Defaults to BST_DIRECT_REFERENCE. May
+     *        be <code>null</code>.
+     * @return this for chaining
+     */
+    @Nonnull
+    public final IMPLTYPE encryptionKeyIdentifierType (@Nullable final ECryptoKeyIdentifierType eEncryptionKeyIdentifierType)
+    {
+      m_eEncryptionKeyIdentifierType = eEncryptionKeyIdentifierType;
+      return thisAsT ();
+    }
+
+    /**
+     * Signing Key Identifier Type.
+     *
+     * @param eSigningKeyIdentifierType
+     *        {@link ECryptoKeyIdentifierType}. Defaults to BST_DIRECT_REFERENCE. May
+     *        be <code>null</code>.
+     * @return this for chaining
+     */
+    @Nonnull
+    public final IMPLTYPE setSigningKeyIdentifierType (@Nullable final ECryptoKeyIdentifierType eSigningKeyIdentifierType)
+    {
+      m_eSigningKeyIdentifierType = eSigningKeyIdentifierType;
+      return thisAsT ();
+    }
+
+    /**
+     * Set the payload to be send out.
+     *
+     * @param aBuilder
+     *        The payload builder to be used. GZip compression is automatically.
+     *        enforced.
+     * @param aPayloadParams
+     *        The payload params to use. May be <code>null</code>.
+     * @return this for chaining
+     */
+    @Nonnull
+    public final IMPLTYPE payload (@Nullable final AS4OutgoingAttachment.Builder aBuilder,
+                                   @Nullable final BDEWPayloadParams aPayloadParams)
+    {
+      m_aPayload = aBuilder != null ? aBuilder.compressionGZIP ().build () : null;
+      m_aPayloadParams = aPayloadParams;
+      return thisAsT ();
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public boolean isEveryRequiredFieldSet ()
+    {
+      if (!super.isEveryRequiredFieldSet ())
+        return false;
+
+      if (m_aPayload == null)
+      {
+        LOGGER.warn ("The field 'payload' is not set");
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    protected final void mainSendMessage () throws Phase4Exception
+    {
+      // Temporary file manager
+      try (final AS4ResourceHelper aResHelper = new AS4ResourceHelper ())
+      {
+        // Start building AS4 User Message
+        final AS4ClientUserMessage aUserMsg = new AS4ClientUserMessage (aResHelper);
+        applyToUserMessage (aUserMsg);
+
+        aUserMsg.cryptParams ().setKeyEncAlgorithm (ECryptoKeyEncryptionAlgorithm.ECDH_ES_KEYWRAP_AES_128);
+        aUserMsg.cryptParams ().setKeyIdentifierType (m_eEncryptionKeyIdentifierType);
+        aUserMsg.signingParams ().setKeyIdentifierType (m_eSigningKeyIdentifierType);
+        // Empty string by purpose
+        aUserMsg.setConversationID ("");
+
+        // No payload - only one attachment
+        aUserMsg.setPayload (null);
+
+        // Add main attachment
+        final WSS4JAttachment aPayloadAttachment = WSS4JAttachment.createOutgoingFileAttachment (m_aPayload,
+                                                                                                 aResHelper);
+
+        if (m_aPayloadParams != null)
+        {
+          if (m_aPayloadParams.getDocumentType () != null)
+            aPayloadAttachment.customPartProperties ().put ("BDEWDocumentType", m_aPayloadParams.getDocumentType ());
+          if (m_aPayloadParams.getDocumentDate () != null)
+            aPayloadAttachment.customPartProperties ().put ("BDEWDocumentDate",
+                    m_aPayloadParams.getDocumentDate ().withZoneSameInstant (ZoneOffset.UTC).toString ());
+          if (m_aPayloadParams.getDocumentNumber () != null)
+            aPayloadAttachment.customPartProperties ().put ("BDEWDocumentNo", String.valueOf (m_aPayloadParams.getDocumentNumber ()));
+          if (m_aPayloadParams.getFulfillmentDate () != null)
+            aPayloadAttachment.customPartProperties ().put ("BDEWFulfillmentDate",
+                    m_aPayloadParams.getFulfillmentDate ().withZoneSameInstant (ZoneOffset.UTC).toString ());
+          if (m_aPayloadParams.getSubjectPartyId () != null)
+            aPayloadAttachment.customPartProperties ().put ("BDEWSubjectPartyID", m_aPayloadParams.getSubjectPartyId ());
+          if (m_aPayloadParams.getSubjectPartyRole () != null)
+            aPayloadAttachment.customPartProperties ().put ("BDEWSubjectPartyRole", m_aPayloadParams.getSubjectPartyRole ());
+        }
+        aUserMsg.addAttachment (aPayloadAttachment);
+
+        // Add other attachments
+        for (final AS4OutgoingAttachment aAttachment : m_aAttachments)
+          aUserMsg.addAttachment (WSS4JAttachment.createOutgoingFileAttachment (aAttachment, aResHelper));
+
+        // Main sending
+        AS4BidirectionalClientHelper.sendAS4UserMessageAndReceiveAS4SignalMessage (m_aCryptoFactory,
+                                                                                   pmodeResolver (),
+                                                                                   incomingAttachmentFactory (),
+                                                                                   incomingProfileSelector (),
+                                                                                   aUserMsg,
+                                                                                   m_aLocale,
+                                                                                   m_sEndpointURL,
+                                                                                   m_aBuildMessageCallback,
+                                                                                   m_aOutgoingDumper,
+                                                                                   m_aIncomingDumper,
+                                                                                   m_aRetryCallback,
+                                                                                   m_aResponseConsumer,
+                                                                                   m_aSignalMsgConsumer);
+      }
+      catch (final Phase4Exception ex)
+      {
+        // Re-throw
+        throw ex;
+      }
+      catch (final Exception ex)
+      {
+        // wrap
+        throw new Phase4Exception ("Wrapped Phase4Exception", ex);
+      }
+    }
+  }
+
+  /**
+   * The builder class for sending AS4 messages using BDEW profile specifics.
+   * Use {@link #sendMessage()} to trigger the main transmission.
+   *
+   * @author Philip Helger
+   */
+  public static class BDEWUserMessageBuilder extends AbstractBDEWUserMessageBuilder<BDEWUserMessageBuilder>
+  {
+    public BDEWUserMessageBuilder()
+    {}
+  }
+
+  /**
+   * Additional parameters to add in the PayloadInfo part of AS4 UserMessage
+   *
+   * @author Gregor Scholtysik
+   */
+  @NotThreadSafe
+  public static class BDEWPayloadParams
+  {
+    private String m_sDocumentType;
+    private ZonedDateTime m_sDocumentDate;
+    private Integer m_sDocumentNumber;
+    private ZonedDateTime m_sFulfillmentDate;
+    private String m_sSubjectPartyID;
+    private String m_sSubjectPartyRole;
+
+    /**
+     * @return BDEW payload document type for payload identifier <code>BDEWDocumentType</code>
+     */
+    @Nullable
+    public String getDocumentType ()
+    {
+      return m_sDocumentType;
+    }
+
+    /**
+     * BDEW payload document type
+     *
+     * @param sDocumentType
+     *        Document type to use. May be <code>null</code>.
+     */
+    public void setDocumentType (@Nullable final String sDocumentType)
+    {
+      m_sDocumentType = sDocumentType;
+    }
+
+    /**
+     * @return BDEW payload document date for payload identifier <code>BDEWDocumentDate</code>
+     */
+    @Nullable
+    public ZonedDateTime getDocumentDate ()
+    {
+      return m_sDocumentDate;
+    }
+
+    /**
+     * BDEW payload document date
+     *
+     * @param sDocumentDate
+     *        Document date to use. May be <code>null</code>.
+     */
+    public void setDocumentDate (@Nullable final ZonedDateTime sDocumentDate)
+    {
+      m_sDocumentDate = sDocumentDate;
+    }
+
+    /**
+     * @return BDEW payload document number for payload identifier <code>BDEWDocumentNo</code>
+     */
+    @Nullable
+    public Integer getDocumentNumber ()
+    {
+      return m_sDocumentNumber;
+    }
+
+    /**
+     * BDEW payload document number
+     *
+     * @param sDocumentNumber
+     *        Document number to use. May be <code>null</code>.
+     */
+    public void setDocumentNumber (@Nullable final Integer sDocumentNumber)
+    {
+      m_sDocumentNumber = sDocumentNumber;
+    }
+
+
+    /**
+     * @return BDEW payload fulfillment date for payload identifier <code>BDEWFulfillmentDate</code>
+     */
+    @Nullable
+    public ZonedDateTime getFulfillmentDate ()
+    {
+      return m_sFulfillmentDate;
+    }
+
+    /**
+     * BDEW payload fulfillment date
+     *
+     * @param sFulfillmenttDate
+     *        Fulfillment date to use. May be <code>null</code>.
+     */
+    public void setFulfillmentDate (@Nullable final ZonedDateTime sFulfillmenttDate)
+    {
+      m_sFulfillmentDate = sFulfillmenttDate;
+    }
+
+    /**
+     * @return BDEW payload subject party ID for payload identifier <code>BDEWSubjectPartyID</code>
+     */
+    @Nullable
+    public String getSubjectPartyId ()
+    {
+      return m_sSubjectPartyID;
+    }
+
+    /**
+     * BDEW payload subject party ID
+     *
+     * @param sSubjectPartyId
+     *        Subject party ID to use. May be <code>null</code>.
+     */
+    public void setSubjectPartyId (@Nullable final String sSubjectPartyId)
+    {
+      m_sSubjectPartyID = sSubjectPartyId;
+    }
+
+    /**
+     * @return BDEW payload subject party ID for payload identifier <code>BDEWSubjectPartyRole</code>
+     */
+    @Nullable
+    public String getSubjectPartyRole ()
+    {
+      return m_sSubjectPartyRole;
+    }
+
+    /**
+     * BDEW payload subject party role
+     *
+     * @param sSubjectPartyRole
+     *        Subject party role to use. May be <code>null</code>.
+     */
+    public void setSubjectPartyRole (@Nullable final String sSubjectPartyRole)
+    {
+      m_sSubjectPartyRole = sSubjectPartyRole;
+    }
+  }
+}

--- a/phase4-bdew-client/src/main/resources/LICENSE
+++ b/phase4-bdew-client/src/main/resources/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/phase4-bdew-client/src/main/resources/NOTICE
+++ b/phase4-bdew-client/src/main/resources/NOTICE
@@ -1,0 +1,5 @@
+=============================================================================
+= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+=============================================================================
+This product includes Open Source Software developed by
+Philip Helger - https://www.helger.com/

--- a/phase4-bdew-client/src/test/java/com/helger/phase4/bdew/Phase4BDEWHttpClientSettingsTest.java
+++ b/phase4-bdew-client/src/test/java/com/helger/phase4/bdew/Phase4BDEWHttpClientSettingsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.bdew;
+
+import org.junit.Test;
+
+import java.security.GeneralSecurityException;
+
+/**
+ * Test class for class {@link Phase4BDEWHttpClientSettings}
+ *
+ * @author Gregor Scholtysik
+ */
+public class Phase4BDEWHttpClientSettingsTest
+{
+  @Test
+  public void testBasic () throws GeneralSecurityException
+  {
+    new Phase4BDEWHttpClientSettings ();
+  }
+}

--- a/phase4-bdew-client/src/test/java/com/helger/phase4/bdew/SPITest.java
+++ b/phase4-bdew-client/src/test/java/com/helger/phase4/bdew/SPITest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.bdew;
+
+import com.helger.commons.mock.SPITestHelper;
+import org.junit.Test;
+
+/**
+ * Test SPI definitions
+ *
+ * @author Gregor Scholtysik
+ */
+public final class SPITest
+{
+  @Test
+  public void testBasic () throws Exception
+  {
+    SPITestHelper.testIfAllSPIImplementationsAreValid ();
+  }
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/crypto/AS4CryptParams.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/crypto/AS4CryptParams.java
@@ -1,5 +1,8 @@
 /*
- * Copyright (C) 2015-2023 Philip Helger (www.helger.com)
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * * Copyright (C) 2015-2023 Philip Helger (www.helger.com)
  * philip[at]helger[dot]com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,7 +52,6 @@ import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
 public class AS4CryptParams implements Serializable, ICloneable <AS4CryptParams>
 {
   public static final ECryptoKeyIdentifierType DEFAULT_KEY_IDENTIFIER_TYPE = ECryptoKeyIdentifierType.BST_DIRECT_REFERENCE;
-  public static final String DEFAULT_KEY_ENC_ALGORITHM = WSS4JConstants.KEYTRANSPORT_RSAOAEP_XENC11;
   public static final String DEFAULT_MGF_ALGORITHM = WSS4JConstants.MGF_SHA256;
   public static final String DEFAULT_DIGEST_ALGORITHM = WSS4JConstants.SHA256;
 
@@ -60,7 +62,7 @@ public class AS4CryptParams implements Serializable, ICloneable <AS4CryptParams>
   // The algorithm to use
   private ECryptoAlgorithmCrypt m_eAlgorithmCrypt;
   // The key encryption algorithm
-  private String m_sKeyEncAlgorithm = DEFAULT_KEY_ENC_ALGORITHM;
+  private ECryptoKeyEncryptionAlgorithm m_eKeyEncAlgorithm = ECryptoKeyEncryptionAlgorithm.RSA_OAEP_XENC11;
   // The MGF algorithm to use with the RSA-OAEP key transport algorithm
   private String m_sMGFAlgorithm = DEFAULT_MGF_ALGORITHM;
   // The digest algorithm to use with the RSA-OAEP key transport algorithm
@@ -73,7 +75,8 @@ public class AS4CryptParams implements Serializable, ICloneable <AS4CryptParams>
   /**
    * Default constructor using default
    * {@link #setKeyIdentifierType(ECryptoKeyIdentifierType)},
-   * {@link #setKeyEncAlgorithm(String)}, {@link #setMGFAlgorithm(String)} and
+   * {@link #setKeyEncAlgorithm(ECryptoKeyEncryptionAlgorithm)},
+   * {@link #setMGFAlgorithm(String)} and
    * {@link #setDigestAlgorithm(String)}
    */
   public AS4CryptParams ()
@@ -148,15 +151,15 @@ public class AS4CryptParams implements Serializable, ICloneable <AS4CryptParams>
 
   @Nonnull
   @Nonempty
-  public final String getKeyEncAlgorithm ()
+  public final ECryptoKeyEncryptionAlgorithm getKeyEncAlgorithm ()
   {
-    return m_sKeyEncAlgorithm;
+    return m_eKeyEncAlgorithm;
   }
 
   @Nonnull
-  public final AS4CryptParams setKeyEncAlgorithm (@Nonnull @Nonempty final String sKeyEncAlgorithm)
+  public final AS4CryptParams setKeyEncAlgorithm (@Nonnull @Nonempty final ECryptoKeyEncryptionAlgorithm eKeyEncAlgorithm)
   {
-    m_sKeyEncAlgorithm = sKeyEncAlgorithm;
+    m_eKeyEncAlgorithm = eKeyEncAlgorithm;
     return this;
   }
 
@@ -312,7 +315,7 @@ public class AS4CryptParams implements Serializable, ICloneable <AS4CryptParams>
   {
     return new AS4CryptParams ().setKeyIdentifierType (m_eKeyIdentifierType)
                                 .setAlgorithmCrypt (m_eAlgorithmCrypt)
-                                .setKeyEncAlgorithm (m_sKeyEncAlgorithm)
+                                .setKeyEncAlgorithm (m_eKeyEncAlgorithm)
                                 .setMGFAlgorithm (m_sMGFAlgorithm)
                                 .setDigestAlgorithm (m_sDigestAlgorithm)
                                 .setCertificate (m_aCert)
@@ -324,7 +327,7 @@ public class AS4CryptParams implements Serializable, ICloneable <AS4CryptParams>
   {
     return new ToStringGenerator (null).append ("KeyIdentifierType", m_eKeyIdentifierType)
                                        .append ("AlgorithmCrypt", m_eAlgorithmCrypt)
-                                       .append ("KeyEncAlgorithm", m_sKeyEncAlgorithm)
+                                       .append ("KeyEncAlgorithm", m_eKeyEncAlgorithm)
                                        .append ("MGFAlgorithm", m_sMGFAlgorithm)
                                        .append ("DigestAlgorithm", m_sDigestAlgorithm)
                                        .append ("Certificate", m_aCert)

--- a/phase4-lib/src/main/java/com/helger/phase4/crypto/ECryptoKeyEncryptionAlgorithm.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/crypto/ECryptoKeyEncryptionAlgorithm.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.crypto;
+
+import com.helger.commons.annotation.Nonempty;
+import com.helger.commons.id.IHasID;
+import org.apache.wss4j.common.WSS4JConstants;
+
+import javax.annotation.Nonnull;
+
+public enum ECryptoKeyEncryptionAlgorithm implements IHasID<String> {
+    RSA_OAEP_XENC11(WSS4JConstants.KEYTRANSPORT_RSAOAEP_XENC11),
+
+    // ECDH-ES KEYWRAP is not supported by WSS4J
+    ECDH_ES_KEYWRAP_AES_128("http://www.w3.org/2001/04/xmlenc#kw-aes128"),
+    ECDH_ES_KEYWRAP_AES_192("http://www.w3.org/2001/04/xmlenc#kw-aes192"),
+    ECDH_ES_KEYWRAP_AES_256("http://www.w3.org/2001/04/xmlenc#kw-aes256");
+
+    private final String m_sID;
+
+    ECryptoKeyEncryptionAlgorithm (@Nonnull @Nonempty final String sID) {
+        this.m_sID = sID;
+    }
+
+    @Override
+    public String getID () {
+        return m_sID;
+    }
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/messaging/crypto/AS4Encryptor.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/messaging/crypto/AS4Encryptor.java
@@ -78,7 +78,7 @@ public final class AS4Encryptor
     // signing certificate.
     aBuilder.setKeyIdentifierType (aCryptParams.getKeyIdentifierType ().getTypeID ());
     aBuilder.setSymmetricEncAlgorithm (aCryptParams.getAlgorithmCrypt ().getAlgorithmURI ());
-    aBuilder.setKeyEncAlgo (aCryptParams.getKeyEncAlgorithm ());
+    aBuilder.setKeyEncAlgo (aCryptParams.getKeyEncAlgorithm ().getID ());
     aBuilder.setMGFAlgorithm (aCryptParams.getMGFAlgorithm ());
     aBuilder.setDigestAlgorithm (aCryptParams.getDigestAlgorithm ());
     // Encrypted key must be contained

--- a/phase4-profile-bdew/pom.xml
+++ b/phase4-profile-bdew/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+    gregor[dot]scholtysik[at]soptim[dot]de
+
+    Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+    philip[at]helger[dot]com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.helger.phase4</groupId>
+        <artifactId>phase4-parent-pom</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>phase4-profile-bdew</artifactId>
+    <inceptionYear>2023</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>gregorscholtysik</id>
+            <name>Gregor Scholtysik</name>
+            <email>gregor.scholtysik@soptim.de</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.helger.phase4</groupId>
+            <artifactId>phase4-lib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Automatic-Module-Name>com.helger.phase4.profile.bdew</Automatic-Module-Name>
+                        <Export-Package>com.helger.phase4.profile.bdew.*</Export-Package>
+                        <Import-Package>!javax.annotation.*,*</Import-Package>
+                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
+                        <Provide-Capability>osgi.serviceloader; osgi.serviceloader=com.helger.phase4.profile.IAS4ProfileRegistrarSPI</Provide-Capability>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/phase4-profile-bdew/src/etc/javadoc.css
+++ b/phase4-profile-bdew/src/etc/javadoc.css
@@ -1,0 +1,586 @@
+/**
+ * Copyright (C) 2015-2021 Pavel Rotek
+ * pavel[dot]rotek[at]gmail[dot]com
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * based on phloc javadoc CSS.
+ * (c) 2011-2014 phloc systems.
+ * Derived from the original javadoc CSS from Sun JDK
+ */
+ 
+body {
+	background-color: #FFFFFF;
+	color: #353833;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 76%;
+	margin: 0;
+}
+
+a:link,a:visited {
+	color: #880000;
+	text-decoration: none;
+}
+
+a:hover,a:focus {
+	color: #BB2222;
+	text-decoration: none;
+}
+
+a:active {
+	color: #4C6B87;
+	text-decoration: none;
+}
+
+a[name] {
+	color: #353833;
+}
+
+a[name]:hover {
+	color: #353833;
+	text-decoration: none;
+}
+
+pre {
+	font-size: 1.3em;
+}
+
+h1 {
+	font-size: 1.8em;
+}
+
+h2 {
+	font-size: 1.5em;
+}
+
+h3 {
+	font-size: 1.4em;
+}
+
+h4 {
+	font-size: 1.3em;
+}
+
+h5 {
+	font-size: 1.2em;
+}
+
+h6 {
+	font-size: 1.1em;
+}
+
+ul {
+	list-style-type: disc;
+}
+
+code,tt {
+	font-size: 1.2em;
+}
+
+dt code {
+	font-size: 1.2em;
+}
+
+table tr td dt code {
+	font-size: 1.2em;
+	vertical-align: top;
+}
+
+sup {
+	font-size: 0.6em;
+}
+
+.clear {
+	clear: both;
+	height: 0;
+	overflow: hidden;
+}
+
+.aboutLanguage {
+	float: right;
+	font-size: 0.8em;
+	margin-top: -7px;
+	padding: 0 21px;
+	z-index: 200;
+}
+
+.legalCopy {
+	margin-left: 0.5em;
+}
+
+.bar a,.bar a:link,.bar a:visited,.bar a:active {
+	color: #FFFFFF;
+	text-decoration: none;
+}
+
+.bar a:hover,.bar a:focus {
+	color: #BB7A2A;
+}
+
+.tab {
+	background-color: #0066FF;
+	background-image: url("resources/titlebar.gif");
+	background-position: left top;
+	background-repeat: no-repeat;
+	color: #FFFFFF;
+	font-weight: bold;
+	padding: 8px;
+	width: 5em;
+}
+
+.bar {
+	background-image: url("resources/background.gif");
+	background-repeat: repeat-x;
+	color: #FFFFFF;
+	font-size: 1em;
+	height: auto;
+	margin: 0;
+	padding: 0.8em 0.5em 0.4em 0.8em;
+}
+
+.topNav {
+	background-image: url("resources/background.gif");
+	background-repeat: repeat-x;
+	clear: right;
+	color: #FFFFFF;
+	float: left;
+	height: 2.8em;
+	overflow: hidden;
+	padding: 10px 0 0;
+	width: 100%;
+}
+
+.bottomNav {
+	background-image: url("resources/background.gif");
+	background-repeat: repeat-x;
+	clear: right;
+	color: #FFFFFF;
+	float: left;
+	height: 2.8em;
+	margin-top: 10px;
+	overflow: hidden;
+	padding: 10px 0 0;
+	width: 100%;
+}
+
+.subNav {
+	background-color: #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	float: left;
+	overflow: hidden;
+	width: 100%;
+}
+
+.subNav div {
+	clear: left;
+	float: left;
+	padding: 0 0 5px 6px;
+}
+
+ul.navList,ul.subNavList {
+	float: left;
+	margin: 0 25px 0 0;
+	padding: 0;
+}
+
+ul.navList li {
+	float: left;
+	list-style: none outside none;
+	padding: 3px 6px;
+}
+
+ul.subNavList li {
+	float: left;
+	font-size: 90%;
+	list-style: none outside none;
+}
+
+.topNav a:link,.topNav a:active,.topNav a:visited,.bottomNav a:link,.bottomNav a:active,.bottomNav a:visited
+	{
+	color: #FFFFFF;
+	text-decoration: none;
+}
+
+.topNav a:hover,.bottomNav a:hover {
+	color: #BB7A2A;
+	text-decoration: none;
+}
+
+.navBarCell1Rev {
+	background-color: #A88834;
+	background-image: url("resources/tab.gif");
+	border: 1px solid #C9AA44;
+	color: #FFFFFF;
+	margin: auto 5px;
+}
+
+.header,.footer {
+	clear: both;
+	margin: 0 20px;
+	padding: 5px 0 0;
+}
+
+.indexHeader {
+	margin: 10px;
+	position: relative;
+}
+
+.indexHeader h1 {
+	font-size: 1.3em;
+}
+
+.title {
+	color: #880000;
+	margin: 10px 0;
+}
+
+.subTitle {
+	margin: 5px 0 0;
+}
+
+.header ul {
+	margin: 0 0 25px;
+	padding: 0;
+}
+
+.footer ul {
+	margin: 20px 0 5px;
+}
+
+.header ul li,.footer ul li {
+	font-size: 1.2em;
+	list-style: none outside none;
+}
+
+div.details ul.blockList ul.blockList ul.blockList li.blockList h4,div.details ul.blockList ul.blockList ul.blockListLast li.blockList h4
+	{
+	background-color: #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	border-top: 1px solid #9EADC0;
+	margin: 0 0 6px -8px;
+	padding: 2px 5px;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList h3 {
+	background-color: #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	border-top: 1px solid #9EADC0;
+	margin: 0 0 6px -8px;
+	padding: 2px 5px;
+}
+
+ul.blockList ul.blockList li.blockList h3 {
+	margin: 15px 0;
+	padding: 0;
+}
+
+ul.blockList li.blockList h2 {
+	padding: 0 0 20px;
+}
+
+.contentContainer,.sourceContainer,.classUseContainer,.serializedFormContainer,.constantValuesContainer
+	{
+	clear: both;
+	padding: 10px 20px;
+	position: relative;
+}
+
+.indexContainer {
+	font-size: 1em;
+	margin: 10px;
+	position: relative;
+}
+
+.indexContainer h2 {
+	font-size: 1.1em;
+	padding: 0 0 3px;
+}
+
+.indexContainer ul {
+	margin: 0;
+	padding: 0;
+}
+
+.indexContainer ul li {
+	list-style: none outside none;
+}
+
+.contentContainer .description dl dt,.contentContainer .details dl dt,.serializedFormContainer dl dt
+	{
+	color: #4E4E4E;
+	font-size: 1.1em;
+	font-weight: bold;
+	margin: 10px 0 0;
+}
+
+.contentContainer .description dl dd,.contentContainer .details dl dd,.serializedFormContainer dl dd
+	{
+	margin: 10px 0 10px 20px;
+}
+
+.serializedFormContainer dl.nameValue dt {
+	display: inline;
+	font-size: 1.1em;
+	font-weight: bold;
+	margin-left: 1px;
+}
+
+.serializedFormContainer dl.nameValue dd {
+	display: inline;
+	font-size: 1.1em;
+}
+
+ul.horizontal li {
+	display: inline;
+	font-size: 0.9em;
+}
+
+ul.inheritance {
+	margin: 0;
+	padding: 0;
+}
+
+ul.inheritance li {
+	display: inline;
+	list-style: none outside none;
+}
+
+ul.inheritance li ul.inheritance {
+	margin-left: 15px;
+	padding-left: 15px;
+	padding-top: 1px;
+}
+
+ul.blockList,ul.blockListLast {
+	margin: 10px 0;
+	padding: 0;
+}
+
+ul.blockList li.blockList,ul.blockListLast li.blockList {
+	list-style: none outside none;
+	margin-bottom: 25px;
+}
+
+ul.blockList ul.blockList li.blockList,ul.blockList ul.blockListLast li.blockList
+	{
+	background-color: #F9F9F9;
+	border: 1px solid #9EADC0;
+	padding: 0 20px 5px 10px;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList,ul.blockList ul.blockList ul.blockListLast li.blockList
+	{
+	-moz-border-bottom-colors: none;
+	-moz-border-left-colors: none;
+	-moz-border-right-colors: none;
+	-moz-border-top-colors: none;
+	background-color: #FFFFFF;
+	border-color: currentColor #9EADC0 #9EADC0;
+	border-image: none;
+	border-right: 1px solid #9EADC0;
+	border-style: none solid solid;
+	border-width: medium 1px 1px;
+	padding: 0 0 5px 8px;
+}
+
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockList {
+	-moz-border-bottom-colors: none;
+	-moz-border-left-colors: none;
+	-moz-border-right-colors: none;
+	-moz-border-top-colors: none;
+	border-color: currentColor currentColor #9EADC0;
+	border-image: none;
+	border-style: none none solid;
+	border-width: medium medium 1px;
+	margin-left: 0;
+	padding-bottom: 15px;
+	padding-left: 0;
+}
+
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockListLast {
+	border-bottom: medium none;
+	list-style: none outside none;
+	padding-bottom: 0;
+}
+
+table tr td dl,table tr td dl dt,table tr td dl dd {
+	margin-bottom: 1px;
+	margin-top: 0;
+}
+
+.contentContainer table,.classUseContainer table,.constantValuesContainer table
+	{
+	border-bottom: 1px solid #9EADC0;
+	width: 100%;
+}
+
+.contentContainer ul li table,.classUseContainer ul li table,.constantValuesContainer ul li table
+	{
+	width: 100%;
+}
+
+.contentContainer .description table,.contentContainer .details table {
+	border-bottom: medium none;
+}
+
+.contentContainer ul li table th.colOne,.contentContainer ul li table th.colFirst,.contentContainer ul li table th.colLast,.classUseContainer ul li table th,.constantValuesContainer ul li table th,.contentContainer ul li table td.colOne,.contentContainer ul li table td.colFirst,.contentContainer ul li table td.colLast,.classUseContainer ul li table td,.constantValuesContainer ul li table td
+	{
+	padding-right: 20px;
+	vertical-align: top;
+}
+
+.contentContainer ul li table th.colLast,.classUseContainer ul li table th.colLast,.constantValuesContainer ul li table th.colLast,.contentContainer ul li table td.colLast,.classUseContainer ul li table td.colLast,.constantValuesContainer ul li table td.colLast,.contentContainer ul li table th.colOne,.classUseContainer ul li table th.colOne,.contentContainer ul li table td.colOne,.classUseContainer ul li table td.colOne
+	{
+	padding-right: 3px;
+}
+
+.overviewSummary caption,.packageSummary caption,.contentContainer ul.blockList li.blockList caption,.summary caption,.classUseContainer caption,.constantValuesContainer caption
+	{
+	background-repeat: no-repeat;
+	clear: none;
+	color: #FFFFFF;
+	font-weight: bold;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+	position: relative;
+	text-align: left;
+}
+
+caption a:link,caption a:hover,caption a:active,caption a:visited {
+	color: #FFFFFF;
+}
+
+.overviewSummary caption span,.packageSummary caption span,.contentContainer ul.blockList li.blockList caption span,.summary caption span,.classUseContainer caption span,.constantValuesContainer caption span
+	{
+	background-image: url("resources/titlebar.gif");
+	display: block;
+	float: left;
+	height: 18px;
+	padding-left: 8px;
+	padding-top: 8px;
+	white-space: nowrap;
+}
+
+.overviewSummary .tabEnd,.packageSummary .tabEnd,.contentContainer ul.blockList li.blockList .tabEnd,.summary .tabEnd,.classUseContainer .tabEnd,.constantValuesContainer .tabEnd
+	{
+	background-image: url("resources/titlebar_end.gif");
+	background-position: right top;
+	background-repeat: no-repeat;
+	float: left;
+	position: relative;
+	width: 10px;
+}
+
+ul.blockList ul.blockList li.blockList table {
+	margin: 0 0 12px;
+	width: 100%;
+}
+
+.tableSubHeadingColor {
+	background-color: #EEEEFF;
+}
+
+.altColor {
+	background-color: #EEEEEF;
+}
+
+.rowColor {
+	background-color: #FFFFFF;
+}
+
+.overviewSummary td,.packageSummary td,.contentContainer ul.blockList li.blockList td,.summary td,.classUseContainer td,.constantValuesContainer td
+	{
+	padding: 3px 3px 3px 7px;
+	text-align: left;
+}
+
+th.colFirst,th.colLast,th.colOne,.constantValuesContainer th {
+	background: none repeat scroll 0 0 #DEE3E9;
+	border-bottom: 1px solid #9EADC0;
+	border-top: 1px solid #9EADC0;
+	padding: 3px 3px 3px 7px;
+	text-align: left;
+}
+
+td.colOne a:link,td.colOne a:active,td.colOne a:visited,td.colOne a:hover,td.colFirst a:link,td.colFirst a:active,td.colFirst a:visited,td.colFirst a:hover,td.colLast a:link,td.colLast a:active,td.colLast a:visited,td.colLast a:hover,.constantValuesContainer td a:link,.constantValuesContainer td a:active,.constantValuesContainer td a:visited,.constantValuesContainer td a:hover
+	{
+	font-weight: bold;
+}
+
+td.colFirst,th.colFirst {
+	border-left: 1px solid #9EADC0;
+	white-space: nowrap;
+}
+
+td.colLast,th.colLast {
+	border-right: 1px solid #9EADC0;
+}
+
+td.colOne,th.colOne {
+	border-left: 1px solid #9EADC0;
+	border-right: 1px solid #9EADC0;
+}
+
+table.overviewSummary {
+	margin-left: 0;
+	padding: 0;
+}
+
+table.overviewSummary td.colFirst,table.overviewSummary th.colFirst,table.overviewSummary td.colOne,table.overviewSummary th.colOne
+	{
+	vertical-align: middle;
+	width: 25%;
+}
+
+table.packageSummary td.colFirst,table.overviewSummary th.colFirst {
+	vertical-align: middle;
+	width: 25%;
+}
+
+.description pre {
+	margin-top: 0;
+}
+
+.deprecatedContent {
+	margin: 0;
+	padding: 10px 0;
+}
+
+.docSummary {
+	padding: 0;
+}
+
+.sourceLineNo {
+	color: #008000;
+	padding: 0 30px 0 0;
+}
+
+h1.hidden {
+	font-size: 0.9em;
+	overflow: hidden;
+	visibility: hidden;
+}
+
+.block {
+	display: block;
+	margin: 3px 0 0;
+}
+
+.strong {
+	font-weight: bold;
+}

--- a/phase4-profile-bdew/src/etc/license-template.txt
+++ b/phase4-profile-bdew/src/etc/license-template.txt
@@ -1,0 +1,14 @@
+Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+gregor[dot]scholtysik[at]soptim[dot]de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/AS4BDEWProfileRegistarSPI.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/AS4BDEWProfileRegistarSPI.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.profile.bdew;
+
+import com.helger.commons.annotation.IsSPIImplementation;
+import com.helger.phase4.model.pmode.IPModeIDProvider;
+import com.helger.phase4.profile.AS4Profile;
+import com.helger.phase4.profile.IAS4ProfilePModeProvider;
+import com.helger.phase4.profile.IAS4ProfileRegistrar;
+import com.helger.phase4.profile.IAS4ProfileRegistrarSPI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Library specific implementation of {@link IAS4ProfileRegistrarSPI}.
+ *
+ * @author Gregor Scholtysik
+ */
+@IsSPIImplementation
+public final class AS4BDEWProfileRegistarSPI implements IAS4ProfileRegistrarSPI
+{
+  public static final String AS4_PROFILE_ID = "bdew";
+  public static final String AS4_PROFILE_NAME = "BDEW";
+  public static final IPModeIDProvider PMODE_ID_PROVIDER = IPModeIDProvider.DEFAULT_DYNAMIC;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger (AS4BDEWProfileRegistarSPI.class);
+
+  public void registerAS4Profile (@Nonnull final IAS4ProfileRegistrar aRegistrar)
+  {
+    final IAS4ProfilePModeProvider aDefaultPModeProvider = (i, r, a) -> BDEWPMode.createBDEWPMode(i, BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW, r, BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW, a, PMODE_ID_PROVIDER, true);
+
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("Registering phase4 profile '" + AS4_PROFILE_ID + "'");
+    final AS4Profile aProfile = new AS4Profile (AS4_PROFILE_ID,
+                                                AS4_PROFILE_NAME,
+                                                BDEWCompatibilityValidator::new,
+                                                aDefaultPModeProvider,
+                                                PMODE_ID_PROVIDER,
+                                                false);
+    aRegistrar.registerProfile (aProfile);
+    aRegistrar.setDefaultProfile (aProfile);
+  }
+}

--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidator.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidator.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.profile.bdew;
+
+import com.helger.commons.ValueEnforcer;
+import com.helger.commons.annotation.Nonempty;
+import com.helger.commons.error.IError;
+import com.helger.commons.error.SingleError;
+import com.helger.commons.error.list.ErrorList;
+import com.helger.commons.string.StringHelper;
+import com.helger.phase4.attachment.EAS4CompressionMode;
+import com.helger.phase4.crypto.ECryptoAlgorithmCrypt;
+import com.helger.phase4.crypto.ECryptoAlgorithmSign;
+import com.helger.phase4.crypto.ECryptoAlgorithmSignDigest;
+import com.helger.phase4.ebms3header.Ebms3AgreementRef;
+import com.helger.phase4.ebms3header.Ebms3From;
+import com.helger.phase4.ebms3header.Ebms3SignalMessage;
+import com.helger.phase4.ebms3header.Ebms3To;
+import com.helger.phase4.ebms3header.Ebms3UserMessage;
+import com.helger.phase4.mgr.MetaAS4Manager;
+import com.helger.phase4.model.EMEP;
+import com.helger.phase4.model.EMEPBinding;
+import com.helger.phase4.model.pmode.IPMode;
+import com.helger.phase4.model.pmode.PModePayloadService;
+import com.helger.phase4.model.pmode.PModeValidationException;
+import com.helger.phase4.model.pmode.leg.EPModeSendReceiptReplyPattern;
+import com.helger.phase4.model.pmode.leg.PModeLeg;
+import com.helger.phase4.model.pmode.leg.PModeLegErrorHandling;
+import com.helger.phase4.model.pmode.leg.PModeLegProtocol;
+import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
+import com.helger.phase4.profile.IAS4ProfileValidator;
+import com.helger.phase4.soap.ESoapVersion;
+import com.helger.phase4.wss.EWSSVersion;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Validate certain requirements imposed by the BDEW project.
+ *
+ * @author Gregor Scholtysik
+ */
+public class BDEWCompatibilityValidator implements IAS4ProfileValidator
+{
+
+  public BDEWCompatibilityValidator()
+  {}
+
+  @Nonnull
+  private static IError _createError (@Nonnull final String sMsg)
+  {
+    return SingleError.builderError ().errorText (sMsg).build ();
+  }
+
+  @Nonnull
+  private static IError _createWarn (@Nonnull final String sMsg)
+  {
+    return SingleError.builderWarn ().errorText (sMsg).build ();
+  }
+
+  private static void _checkIfLegIsValid (@Nonnull final ErrorList aErrorList,
+                                          @Nonnull final PModeLeg aPModeLeg,
+                                          @Nonnull @Nonempty final String sFieldPrefix)
+  {
+    final PModeLegProtocol aLegProtocol = aPModeLeg.getProtocol ();
+    if (aLegProtocol == null)
+    {
+      aErrorList.add (_createError (sFieldPrefix + "Protocol is missing"));
+    }
+    else
+    {
+      // PROTOCOL Address only https allowed
+      final String sAddressProtocol = aLegProtocol.getAddressProtocol ();
+
+      if (StringHelper.hasText (sAddressProtocol))
+      {
+        if (sAddressProtocol.equalsIgnoreCase ("http") || sAddressProtocol.equalsIgnoreCase ("https"))
+        {
+          // Always okay
+        }
+        else
+        {
+          // Other protocol
+          aErrorList.add (_createError (sFieldPrefix + "AddressProtocol '" + sAddressProtocol + "' is unsupported"));
+        }
+      }
+      else
+      {
+        // Empty address protocol
+        aErrorList.add (_createError (sFieldPrefix + "AddressProtocol is missing"));
+      }
+
+      final ESoapVersion eSOAPVersion = aLegProtocol.getSoapVersion ();
+      if (!eSOAPVersion.isAS4Default ())
+      {
+        aErrorList.add (_createError (sFieldPrefix +
+                                      "SoapVersion '" +
+                                      eSOAPVersion.getVersion () +
+                                      "' is unsupported"));
+      }
+    }
+
+    // Only check the security features if a Security Leg is currently present
+    final PModeLegSecurity aPModeLegSecurity = aPModeLeg.getSecurity ();
+    if (aPModeLegSecurity != null)
+    {
+      // Check Certificate
+      if (false)
+        if (aPModeLegSecurity.getX509SignatureCertificate () == null)
+        {
+          aErrorList.add (_createError (sFieldPrefix + "Security.X509SignatureCertificate is missing"));
+        }
+
+      // Check Signature Algorithm
+      if (aPModeLegSecurity.getX509SignatureAlgorithm () == null)
+      {
+        aErrorList.add (_createError (sFieldPrefix + "Security.X509SignatureAlgorithm is missing"));
+      }
+      else
+        if (!aPModeLegSecurity.getX509SignatureAlgorithm ().equals (ECryptoAlgorithmSign.ECDSA_SHA_256))
+        {
+          aErrorList.add (_createError (sFieldPrefix +
+                                        "Security.X509SignatureAlgorithm must use the value '" +
+                                        ECryptoAlgorithmSign.ECDSA_SHA_256.getID () +
+                                        "'"));
+        }
+
+      // Check Hash Function
+      if (aPModeLegSecurity.getX509SignatureHashFunction () == null)
+      {
+        aErrorList.add (_createError (sFieldPrefix + "Security.X509SignatureHashFunction is missing"));
+      }
+      else
+        if (!aPModeLegSecurity.getX509SignatureHashFunction ().equals (ECryptoAlgorithmSignDigest.DIGEST_SHA_256))
+        {
+          aErrorList.add (_createError (sFieldPrefix +
+                                        "Security.X509SignatureHashFunction must use the value '" +
+                                        ECryptoAlgorithmSignDigest.DIGEST_SHA_256.getID () +
+                                        "'"));
+        }
+
+      // Check Encrypt algorithm
+      if (aPModeLegSecurity.getX509EncryptionAlgorithm () == null)
+      {
+        aErrorList.add (_createError (sFieldPrefix + "Security.X509EncryptionAlgorithm is missing"));
+      }
+      else
+        if (!aPModeLegSecurity.getX509EncryptionAlgorithm ().equals (ECryptoAlgorithmCrypt.AES_128_GCM))
+        {
+          aErrorList.add (_createError (sFieldPrefix +
+                                        "Security.X509EncryptionAlgorithm must use the value '" +
+                                        ECryptoAlgorithmCrypt.AES_128_GCM.getID () +
+                                        "' instead of '" +
+                                        aPModeLegSecurity.getX509EncryptionAlgorithm ().getID () +
+                                        "'"));
+        }
+
+      // Check WSS Version = 1.1.1
+      if (aPModeLegSecurity.getWSSVersion () != null)
+      {
+        // Check for WSS - Version if there is one present
+        if (!aPModeLegSecurity.getWSSVersion ().equals (EWSSVersion.WSS_111))
+          aErrorList.add (_createError (sFieldPrefix +
+                                        "Security.WSSVersion must use the value " +
+                                        EWSSVersion.WSS_111 +
+                                        " instead of " +
+                                        aPModeLegSecurity.getWSSVersion ()));
+      }
+
+      if (aPModeLegSecurity.isUsernameTokenCreatedDefined () ||
+          aPModeLegSecurity.isUsernameTokenDigestDefined () ||
+          aPModeLegSecurity.isUsernameTokenNonceDefined () ||
+          aPModeLegSecurity.hasUsernameTokenPassword () ||
+          aPModeLegSecurity.hasUsernameTokenUsername ())
+      {
+        aErrorList.add (_createError (sFieldPrefix + "Username nor it's part MUST NOT be set"));
+      }
+
+      // PModeAuthorize
+      if (aPModeLegSecurity.isPModeAuthorizeDefined ())
+      {
+        if (aPModeLegSecurity.isPModeAuthorize ())
+          aErrorList.add (_createError (sFieldPrefix + "Security.PModeAuthorize must be set to 'false'"));
+      }
+      else
+      {
+        aErrorList.add (_createError (sFieldPrefix + "Security.PModeAuthorize is missing"));
+      }
+
+      // SEND RECEIPT TRUE/FALSE when false don't send receipts anymore
+      if (aPModeLegSecurity.isSendReceiptDefined ())
+      {
+        if (aPModeLegSecurity.isSendReceipt ())
+        {
+          // set response required
+          if (!aPModeLegSecurity.isSendReceiptNonRepudiation ())
+            aErrorList.add (_createError (sFieldPrefix + "SendReceiptNonRepudiation must be set to 'true'"));
+
+          if (aPModeLegSecurity.getSendReceiptReplyPattern () != EPModeSendReceiptReplyPattern.RESPONSE)
+            aErrorList.add (_createError (sFieldPrefix +
+                                          "Security.SendReceiptReplyPattern must use the value " +
+                                          EPModeSendReceiptReplyPattern.RESPONSE +
+                                          " instead of " +
+                                          aPModeLegSecurity.getSendReceiptReplyPattern ()));
+        }
+      }
+    }
+    else
+    {
+      aErrorList.add (_createError (sFieldPrefix + "Security is missing"));
+    }
+
+    // Error Handling
+    final PModeLegErrorHandling aErrorHandling = aPModeLeg.getErrorHandling ();
+    if (aErrorHandling != null)
+    {
+      if (aErrorHandling.isReportAsResponseDefined ())
+      {
+        if (!aErrorHandling.isReportAsResponse ())
+          aErrorList.add (_createError (sFieldPrefix + "ErrorHandling.Report.AsResponse must be 'true'"));
+      }
+      else
+      {
+        aErrorList.add (_createError (sFieldPrefix + "ErrorHandling.Report.AsResponse is missing"));
+      }
+      if (aErrorHandling.isReportProcessErrorNotifyConsumerDefined ())
+      {
+        if (!aErrorHandling.isReportProcessErrorNotifyConsumer ())
+          aErrorList.add (_createWarn (sFieldPrefix +
+                                       "ErrorHandling.Report.ProcessErrorNotifyConsumer should be 'true'"));
+      }
+      else
+      {
+        aErrorList.add (_createError (sFieldPrefix + "ErrorHandling.Report.ProcessErrorNotifyConsumer is missing"));
+      }
+
+      if (aErrorHandling.isReportProcessErrorNotifyProducerDefined ())
+      {
+        if (!aErrorHandling.isReportProcessErrorNotifyProducer ())
+          aErrorList.add (_createWarn (sFieldPrefix +
+                                       "ErrorHandling.Report.ProcessErrorNotifyProducer should be 'true'"));
+      }
+      else
+      {
+        aErrorList.add (_createError (sFieldPrefix + "ErrorHandling.Report.ProcessErrorNotifyProducer is missing"));
+      }
+
+      if (aErrorHandling.getReportSenderErrorsTo () != null &&
+          aErrorHandling.getReportSenderErrorsTo ().addresses () != null &&
+          aErrorHandling.getReportSenderErrorsTo ().addresses ().isNotEmpty ())
+      {
+        aErrorList.add (_createError (sFieldPrefix + "ReportSenderErrorsTo must not be set"));
+      }
+    }
+    else
+    {
+      aErrorList.add (_createError (sFieldPrefix + "ErrorHandling is missing"));
+    }
+  }
+
+  @Override
+  public void validatePMode (@Nonnull final IPMode aPMode, @Nonnull final ErrorList aErrorList)
+  {
+    ValueEnforcer.isTrue (aErrorList.isEmpty (), () -> "Errors in global PMode validation: " + aErrorList);
+
+    try
+    {
+      MetaAS4Manager.getPModeMgr ().validatePMode (aPMode);
+    }
+    catch (final PModeValidationException ex)
+    {
+      aErrorList.add (_createError (ex.getMessage ()));
+    }
+
+    final EMEP eMEP = aPMode.getMEP ();
+    final EMEPBinding eMEPBinding = aPMode.getMEPBinding ();
+
+    if (eMEP == EMEP.ONE_WAY && eMEPBinding == EMEPBinding.PUSH)
+    {
+      // Valid
+    }
+    else
+    {
+      aErrorList.add (_createError ("An invalid combination of PMode MEP (" +
+                                    eMEP +
+                                    ") and MEP binding (" +
+                                    eMEPBinding +
+                                    ") was specified, valid is only one-way/push."));
+    }
+
+    // Leg1 must be present
+    final PModeLeg aPModeLeg1 = aPMode.getLeg1 ();
+    if (aPModeLeg1 == null)
+    {
+      aErrorList.add (_createError ("PMode.Leg[1] is missing"));
+    }
+    else
+    {
+      _checkIfLegIsValid (aErrorList, aPModeLeg1, "PMode.Leg[1].");
+    }
+
+    if (aPMode.getLeg2 () != null)
+    {
+      aErrorList.add (_createError ("PMode.Leg[2] must not be present"));
+    }
+
+    final PModePayloadService aPayloadService = aPMode.getPayloadService ();
+    if (aPayloadService != null)
+    {
+      final EAS4CompressionMode eCompressionMode = aPayloadService.getCompressionMode ();
+      if (eCompressionMode != null)
+      {
+        if (!eCompressionMode.equals (EAS4CompressionMode.GZIP))
+          aErrorList.add (_createError ("PMode.PayloadService.CompressionMode must be " +
+                                        EAS4CompressionMode.GZIP +
+                                        " instead of " +
+                                        eCompressionMode));
+      }
+      else
+      {
+        aErrorList.add (_createError ("PMode.PayloadService.CompressionMode is missing"));
+      }
+    }
+  }
+
+  @Override
+  public void validateUserMessage (@Nonnull final Ebms3UserMessage aUserMsg, @Nonnull final ErrorList aErrorList)
+  {
+    ValueEnforcer.notNull (aUserMsg, "UserMsg");
+
+    if (aUserMsg.getMessageInfo () == null)
+    {
+      aErrorList.add (_createError ("MessageInfo is missing"));
+    }
+    else
+    {
+      if (StringHelper.hasNoText (aUserMsg.getMessageInfo ().getMessageId ()))
+        aErrorList.add (_createError ("MessageInfo/MessageId is missing"));
+
+      if (StringHelper.hasText (aUserMsg.getMessageInfo ().getRefToMessageId ()))
+        aErrorList.add (_createError ("MessageInfo/RefToMessageId must not be set"));
+
+    }
+
+    if (aUserMsg.getPartyInfo () == null)
+    {
+      aErrorList.add (_createError ("PartyInfo is missing"));
+    }
+    else
+    {
+      final Ebms3From aFrom = aUserMsg.getPartyInfo ().getFrom ();
+      if (aFrom != null)
+      {
+        if (aFrom.getPartyIdCount () > 1)
+          aErrorList.add (_createError ("PartyInfo/From must contain no more than one PartyID"));
+      }
+
+      final Ebms3To aTo = aUserMsg.getPartyInfo ().getTo ();
+      if (aTo != null)
+      {
+        if (aTo.getPartyIdCount () > 1)
+          aErrorList.add (_createError ("PartyInfo/To must contain no more than one PartyID"));
+      }
+    }
+
+    if (aUserMsg.getCollaborationInfo () == null)
+    {
+      aErrorList.add (_createError ("CollaborationInfo is missing"));
+    }
+    else
+    {
+      final Ebms3AgreementRef aAgreementRef = aUserMsg.getCollaborationInfo ().getAgreementRef ();
+      if (aAgreementRef == null) {
+        aErrorList.add( _createError ("CollaborationInfo/AgreementRef must be set!"));
+      } else {
+        if (StringHelper.hasNoText (aAgreementRef.getValue ()))
+          aErrorList.add (_createError ("CollaborationInfo/AgreementRef value is missing"));
+        if (!BDEWPMode.DEFAULT_AGREEMENT_ID.equals (aAgreementRef.getValue ()))
+          aErrorList.add (_createError ("CollaborationInfo/AgreementRef value must equal " + BDEWPMode.DEFAULT_AGREEMENT_ID));
+        if (aAgreementRef.getPmode () != null)
+          aErrorList.add (_createError ("CollaborationInfo/PMode must not be set!"));
+        if (aAgreementRef.getType () != null)
+          aErrorList.add (_createError ("CollaborationInfo/Type must not be set!"));
+      }
+    }
+  }
+
+  @Override
+  public void validateSignalMessage (@Nonnull final Ebms3SignalMessage aSignalMsg, @Nonnull final ErrorList aErrorList)
+  {
+    ValueEnforcer.notNull (aSignalMsg, "SignalMsg");
+
+    if (aSignalMsg.getMessageInfo () == null)
+    {
+      aErrorList.add (_createError ("MessageInfo is missing"));
+    }
+    else
+    {
+      if (StringHelper.hasNoText (aSignalMsg.getMessageInfo ().getMessageId ()))
+        aErrorList.add (_createError ("MessageInfo/MessageId is missing"));
+    }
+  }
+}

--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWPMode.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWPMode.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.profile.bdew;
+
+import com.helger.commons.annotation.Nonempty;
+import com.helger.commons.state.ETriState;
+import com.helger.phase4.CAS4;
+import com.helger.phase4.attachment.EAS4CompressionMode;
+import com.helger.phase4.crypto.ECryptoAlgorithmCrypt;
+import com.helger.phase4.crypto.ECryptoAlgorithmSign;
+import com.helger.phase4.crypto.ECryptoAlgorithmSignDigest;
+import com.helger.phase4.mgr.MetaAS4Manager;
+import com.helger.phase4.model.EMEP;
+import com.helger.phase4.model.EMEPBinding;
+import com.helger.phase4.model.pmode.IPModeIDProvider;
+import com.helger.phase4.model.pmode.PMode;
+import com.helger.phase4.model.pmode.PModeParty;
+import com.helger.phase4.model.pmode.PModePayloadService;
+import com.helger.phase4.model.pmode.PModeReceptionAwareness;
+import com.helger.phase4.model.pmode.leg.EPModeSendReceiptReplyPattern;
+import com.helger.phase4.model.pmode.leg.PModeAddressList;
+import com.helger.phase4.model.pmode.leg.PModeLeg;
+import com.helger.phase4.model.pmode.leg.PModeLegBusinessInformation;
+import com.helger.phase4.model.pmode.leg.PModeLegErrorHandling;
+import com.helger.phase4.model.pmode.leg.PModeLegProtocol;
+import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
+import com.helger.phase4.wss.EWSSVersion;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * PMode creation code.
+ *
+ * @author Gregor Scholtysik
+ */
+@Immutable
+public final class BDEWPMode
+{
+  public static final String DEFAULT_AGREEMENT_ID = "https://www.bdew.de/as4/communication/agreement";
+
+  public static final String BDEW_PARTY_ID_TYPE_GLN = "urn:oasis:names:tc:ebcore:partyid-type:iso6523:0088";
+  public static final String BDEW_PARTY_ID_TYPE_BDEW = "urn:oasis:names:tc:ebcore:partyid-type:unregistered:BDEW";
+  public static final String BDEW_PARTY_ID_TYPE_DVGW = "urn:oasis:names:tc:ebcore:partyid-type:unregistered:DVGW";
+
+  public static final String SERVICE_TEST = "http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/service";
+  public static final String SERVICE_PATH_SWITCH = "https://www.bdew.de/as4/communication/services/pathSwitch";
+  public static final String SERVICE_MARKTPROZESSE = "https://www.bdew.de/as4/communication/services/MP";
+  public static final String SERVICE_FAHRPLAN = "https://www.bdew.de/as4/communication/services/FP";
+  public static final String SERVICE_REDISPATCH_2_0 = "https://www.bdew.de/as4/communication/services/RD";
+  public static final String SERVICE_REDISPATCH_KWEP = "https://www.bdew.de/as4/communication/services/KW";
+  public static final String SERVICE_REDISPATCH_SOGL = "https://www.bdew.de/as4/communication/services/SO";
+
+  public static final String ACTION_DEFAULT = "http://docs.oasis-open.org/ebxml-msg/as4/200902/action";
+  public static final String ACTION_TEST_SERVICE = "http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/test";
+  public static final String ACTION_REQUEST_SWITCH = "https://www.bdew.de/as4/communication/actions/requestSwitch";
+  public static final String ACTION_CONFIRM_SWITCH = "https://www.bdew.de/as4/communication/actions/confirmSwitch";
+
+  private BDEWPMode()
+  {}
+
+  @Nonnull
+  public static PModeLegProtocol generatePModeLegProtocol (@Nullable final String sAddress)
+  {
+    // Set the endpoint URL
+    return PModeLegProtocol.createForDefaultSoapVersion (sAddress);
+  }
+
+  @Nonnull
+  public static PModeLegBusinessInformation generatePModeLegBusinessInformation ()
+  {
+    final String sService = null;
+    final String sAction = CAS4.DEFAULT_ACTION_URL;
+    final Long nPayloadProfileMaxKB = null;
+    final String sMPCID = CAS4.DEFAULT_MPC_ID;
+    return PModeLegBusinessInformation.create (sService, sAction, nPayloadProfileMaxKB, sMPCID);
+  }
+
+  @Nonnull
+  public static PModeLegErrorHandling generatePModeLegErrorHandling ()
+  {
+    final PModeAddressList aReportSenderErrorsTo = null;
+    final PModeAddressList aReportReceiverErrorsTo = null;
+    final ETriState eReportAsResponse = ETriState.TRUE;
+    final ETriState eReportProcessErrorNotifyConsumer = ETriState.TRUE;
+    final ETriState eReportProcessErrorNotifyProducer = ETriState.TRUE;
+    final ETriState eReportDeliveryFailuresNotifyProducer = ETriState.TRUE;
+    return new PModeLegErrorHandling (aReportSenderErrorsTo,
+                                      aReportReceiverErrorsTo,
+                                      eReportAsResponse,
+                                      eReportProcessErrorNotifyConsumer,
+                                      eReportProcessErrorNotifyProducer,
+                                      eReportDeliveryFailuresNotifyProducer);
+  }
+
+  @Nonnull
+  public static PModeLegSecurity generatePModeLegSecurity ()
+  {
+    final PModeLegSecurity aPModeLegSecurity = new PModeLegSecurity ();
+    aPModeLegSecurity.setWSSVersion (EWSSVersion.WSS_111);
+    aPModeLegSecurity.setX509SignatureAlgorithm (ECryptoAlgorithmSign.ECDSA_SHA_256);
+    aPModeLegSecurity.setX509SignatureHashFunction (ECryptoAlgorithmSignDigest.DIGEST_SHA_256);
+    aPModeLegSecurity.setX509EncryptionAlgorithm (ECryptoAlgorithmCrypt.AES_128_GCM);
+    aPModeLegSecurity.setX509EncryptionMinimumStrength (128);
+    aPModeLegSecurity.setPModeAuthorize (false);
+    aPModeLegSecurity.setSendReceipt (true);
+    aPModeLegSecurity.setSendReceiptNonRepudiation (true);
+    aPModeLegSecurity.setSendReceiptReplyPattern (EPModeSendReceiptReplyPattern.RESPONSE);
+    return aPModeLegSecurity;
+  }
+
+  @Nonnull
+  public static PModeLeg generatePModeLeg (@Nullable final String sResponderAddress)
+  {
+    return new PModeLeg (generatePModeLegProtocol (sResponderAddress),
+                         generatePModeLegBusinessInformation (),
+                         generatePModeLegErrorHandling (),
+                         null,
+                         generatePModeLegSecurity ());
+  }
+
+  @Nonnull
+  public static PModePayloadService generatePModePayloadSevice ()
+  {
+    return new PModePayloadService (EAS4CompressionMode.GZIP);
+  }
+
+  @Nonnull
+  public static PModeReceptionAwareness generatePModeReceptionAwareness ()
+  {
+    final ETriState eReceptionAwareness = ETriState.TRUE;
+    final ETriState eRetry = ETriState.TRUE;
+    final int nMaxRetries = 1;
+    final long nRetryIntervalMS = 10_000;
+    final ETriState eDuplicateDetection = ETriState.TRUE;
+    return new PModeReceptionAwareness (eReceptionAwareness,
+                                        eRetry,
+                                        nMaxRetries,
+                                        nRetryIntervalMS,
+                                        eDuplicateDetection);
+  }
+
+  /**
+   * One-Way Version of the CEF pmode uses one-way push
+   *
+   * @param sInitiatorID
+   *        Initiator ID
+   * @param sResponderID
+   *        Responder ID
+   * @param sResponderAddress
+   *        Responder URL
+   * @param aPModeIDProvider
+   *        PMode ID provider
+   * @param bPersist
+   *        <code>true</code> to persist the PMode in the PModeManager,
+   *        <code>false</code> to have it only in memory.
+   * @return New PMode
+   */
+  @Nonnull
+  public static PMode createBDEWPMode(@Nonnull @Nonempty final String sInitiatorID,
+                                       @Nonnull @Nonempty final String sInitiatorType,
+                                       @Nonnull @Nonempty final String sResponderID,
+                                       @Nonnull @Nonempty final String sResponderType,
+                                       @Nullable final String sResponderAddress,
+                                       @Nonnull final IPModeIDProvider aPModeIDProvider,
+                                       final boolean bPersist)
+  {
+    final PModeParty aInitiator = new PModeParty (sInitiatorType,
+                                                  sInitiatorID,
+                                                  CAS4.DEFAULT_INITIATOR_URL,
+                                                  null,
+                                                  null);
+    final PModeParty aResponder = new PModeParty (sResponderType,
+                                                  sResponderID,
+                                                  CAS4.DEFAULT_RESPONDER_URL,
+                                                  null,
+                                                  null);
+
+    final PMode aPMode = new PMode (aPModeIDProvider.getPModeID (sInitiatorID, sResponderID),
+                                    aInitiator,
+                                    aResponder,
+                                    DEFAULT_AGREEMENT_ID,
+                                    EMEP.ONE_WAY,
+                                    EMEPBinding.PUSH,
+                                    generatePModeLeg (sResponderAddress),
+                                    null,
+                                    generatePModePayloadSevice (),
+                                    generatePModeReceptionAwareness ());
+
+    // Leg 2 stays null, because we only use one-way
+
+    if (bPersist)
+    {
+      // Ensure it is stored
+      MetaAS4Manager.getPModeMgr ().createOrUpdatePMode (aPMode);
+    }
+    return aPMode;
+  }
+
+}

--- a/phase4-profile-bdew/src/main/resources/META-INF/LICENSE
+++ b/phase4-profile-bdew/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/phase4-profile-bdew/src/main/resources/META-INF/NOTICE
+++ b/phase4-profile-bdew/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,5 @@
+=============================================================================
+= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+=============================================================================
+This product includes Open Source Software developed by
+Philip Helger - https://www.helger.com/

--- a/phase4-profile-bdew/src/main/resources/META-INF/services/com.helger.phase4.profile.IAS4ProfileRegistrarSPI
+++ b/phase4-profile-bdew/src/main/resources/META-INF/services/com.helger.phase4.profile.IAS4ProfileRegistrarSPI
@@ -1,0 +1,1 @@
+com.helger.phase4.profile.bdew.AS4BDEWProfileRegistarSPI

--- a/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidatorTest.java
+++ b/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidatorTest.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.profile.bdew;
+
+import com.helger.commons.error.list.ErrorList;
+import com.helger.commons.state.ETriState;
+import com.helger.phase4.crypto.ECryptoAlgorithmCrypt;
+import com.helger.phase4.crypto.ECryptoAlgorithmSign;
+import com.helger.phase4.crypto.ECryptoAlgorithmSignDigest;
+import com.helger.phase4.ebms3header.Ebms3AgreementRef;
+import com.helger.phase4.ebms3header.Ebms3CollaborationInfo;
+import com.helger.phase4.ebms3header.Ebms3From;
+import com.helger.phase4.ebms3header.Ebms3MessageInfo;
+import com.helger.phase4.ebms3header.Ebms3PartyId;
+import com.helger.phase4.ebms3header.Ebms3PartyInfo;
+import com.helger.phase4.ebms3header.Ebms3SignalMessage;
+import com.helger.phase4.ebms3header.Ebms3To;
+import com.helger.phase4.ebms3header.Ebms3UserMessage;
+import com.helger.phase4.messaging.domain.MessageHelperMethods;
+import com.helger.phase4.model.EMEP;
+import com.helger.phase4.model.EMEPBinding;
+import com.helger.phase4.model.pmode.IPModeIDProvider;
+import com.helger.phase4.model.pmode.PMode;
+import com.helger.phase4.model.pmode.leg.EPModeSendReceiptReplyPattern;
+import com.helger.phase4.model.pmode.leg.PModeLeg;
+import com.helger.phase4.model.pmode.leg.PModeLegErrorHandling;
+import com.helger.phase4.model.pmode.leg.PModeLegProtocol;
+import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
+import com.helger.phase4.soap.ESoapVersion;
+import com.helger.phase4.wss.EWSSVersion;
+import com.helger.photon.app.mock.PhotonAppWebTestRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * All essentials need to be set and need to be not null since they are getting
+ * checked, when a PMode is introduced into the system and these null checks
+ * would be redundant in the profiles.
+ *
+ * @author Gregor Scholtysik
+ */
+public final class BDEWCompatibilityValidatorTest
+{
+  @ClassRule
+  public static final PhotonAppWebTestRule s_aRule = new PhotonAppWebTestRule ();
+
+  private static final Locale LOCALE = Locale.US;
+  private static final BDEWCompatibilityValidator VALIDATOR = new BDEWCompatibilityValidator ();
+
+  private PMode m_aPMode;
+  private ErrorList m_aErrorList;
+
+  @Before
+  public void before ()
+  {
+    m_aErrorList = new ErrorList ();
+    m_aPMode = BDEWPMode.createBDEWPMode ("TestInitiator",
+                                              BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW,
+                                              "TestResponder",
+                                              BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW,
+                                              "http://localhost:8080",
+                                              IPModeIDProvider.DEFAULT_DYNAMIC,
+                                              true);
+  }
+
+  @Test
+  public void testValidatePModeWrongMEP ()
+  {
+    m_aPMode.setMEP (EMEP.TWO_WAY);
+    // Only one-way push allowed
+    m_aPMode.setMEPBinding (EMEPBinding.PULL);
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("MEP")));
+  }
+
+  @Test
+  public void testValidatePModeWrongMEPBinding ()
+  {
+    // SYNC not allowed
+    m_aPMode.setMEPBinding (EMEPBinding.SYNC);
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("MEP binding")));
+  }
+
+  @Test
+  public void testValidatePModeNoLeg ()
+  {
+    m_aPMode.setLeg1 (null);
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("PMode.Leg[1] is missing")));
+  }
+
+  @Test
+  public void testValidatePModeNoProtocol ()
+  {
+    m_aPMode.setLeg1 (new PModeLeg (null, null, null, null, null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("Protocol is missing")));
+  }
+
+  @Test
+  @Ignore ("The response address is most of the time not set")
+  public void testValidatePModeNoProtocolAddress ()
+  {
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion (null), null, null, null, null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("AddressProtocol is missing")));
+  }
+
+  @Test
+  public void testValidatePModeProtocolAddressIsNotHttp ()
+  {
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("ftp://test.com"), null, null, null, null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("AddressProtocol 'ftp' is unsupported")));
+  }
+
+  @Test
+  public void testValidatePModeProtocolSOAP11NotAllowed ()
+  {
+    m_aPMode.setLeg1 (new PModeLeg (new PModeLegProtocol ("https://test.com", ESoapVersion.SOAP_11), null, null, null, null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("SoapVersion '1.1' is unsupported")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityNoX509SignatureAlgorithm ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setX509SignatureAlgorithm (null);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    PModeLegErrorHandling.createUndefined (),
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("X509SignatureAlgorithm is missing")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityWrongX509SignatureAlgorithm ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setX509SignatureAlgorithm (ECryptoAlgorithmSign.ECDSA_SHA_384);
+    assertNotSame (ECryptoAlgorithmSign.ECDSA_SHA_256, aSecurityLeg.getX509SignatureAlgorithm ());
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains (ECryptoAlgorithmSign.ECDSA_SHA_256.getID ())));
+  }
+
+  @Test
+  public void testValidatePModeSecurityNoX509SignatureHashFunction ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setX509SignatureHashFunction (null);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("X509SignatureHashFunction is missing")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityWrongX509SignatureHashFunction ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setX509SignatureHashFunction (ECryptoAlgorithmSignDigest.DIGEST_SHA_512);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains (ECryptoAlgorithmSignDigest.DIGEST_SHA_256.getID ())));
+  }
+
+  @Test
+  public void testValidatePModeSecurityNoX509EncryptionAlgorithm ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setX509EncryptionAlgorithm (null);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("X509EncryptionAlgorithm is missing")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityWrongX509EncryptionAlgorithm ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setX509EncryptionAlgorithm (ECryptoAlgorithmCrypt.AES_192_CBC);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains (ECryptoAlgorithmCrypt.AES_128_GCM.getID ())));
+  }
+
+  @SuppressWarnings ("deprecation")
+  @Test
+  public void testValidatePModeSecurityWrongWSSVersion ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setWSSVersion (EWSSVersion.WSS_10);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE)
+                                                .contains ("Security.WSSVersion must use the value WSS_111 instead of WSS_10")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityPModeAuthorizeMandatory ()
+  {
+    m_aPMode.getLeg1 ().getSecurity ().setPModeAuthorize (ETriState.UNDEFINED);
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue ("Errors: " + m_aErrorList.toString (),
+                m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("Security.PModeAuthorize is missing")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityPModeAuthorizeTrue ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setPModeAuthorize (true);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("false")));
+  }
+
+  @Test
+  public void testValidatePModeSecurityResponsePatternWrongBoolean ()
+  {
+    final PModeLegSecurity aSecurityLeg = m_aPMode.getLeg1 ().getSecurity ();
+    aSecurityLeg.setSendReceipt (true);
+    aSecurityLeg.setSendReceiptReplyPattern (EPModeSendReceiptReplyPattern.CALLBACK);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    null,
+                                    null,
+                                    aSecurityLeg));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE)
+                                                .contains ("Security.SendReceiptReplyPattern must use the value RESPONSE instead of CALLBACK")));
+  }
+
+  // Error Handling
+
+  @Test
+  public void testValidatePModeErrorHandlingMandatory ()
+  {
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"), null, null, null, null));
+
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("PMode.Leg[1].ErrorHandling is missing")));
+  }
+
+  @Test
+  public void testValidatePModeErrorHandlingReportAsResponseMandatory ()
+  {
+    final PModeLegErrorHandling aErrorHandler = PModeLegErrorHandling.createUndefined ();
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    aErrorHandler,
+                                    null,
+                                    null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("ErrorHandling.Report.AsResponse is missing")));
+  }
+
+  @Test
+  public void testValidatePModeErrorHandlingReportAsResponseWrongValue ()
+  {
+    final PModeLegErrorHandling aErrorHandler = PModeLegErrorHandling.createUndefined ();
+    aErrorHandler.setReportAsResponse (false);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    aErrorHandler,
+                                    null,
+                                    null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("ErrorHandling.Report.AsResponse must be 'true'")));
+  }
+
+  @Test
+  public void testValidatePModeErrorHandlingReportProcessErrorNotifyConsumerMandatory ()
+  {
+    final PModeLegErrorHandling aErrorHandler = PModeLegErrorHandling.createUndefined ();
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    aErrorHandler,
+                                    null,
+                                    null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE)
+                                                .contains ("ErrorHandling.Report.ProcessErrorNotifyConsumer is missing")));
+  }
+
+  @Test
+  public void testValidatePModeErrorHandlingReportProcessErrorNotifyConsumerWrongValue ()
+  {
+    final PModeLegErrorHandling aErrorHandler = PModeLegErrorHandling.createUndefined ();
+    aErrorHandler.setReportProcessErrorNotifyConsumer (false);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    aErrorHandler,
+                                    null,
+                                    null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE)
+                                                .contains ("ErrorHandling.Report.ProcessErrorNotifyConsumer should be 'true'")));
+  }
+
+  @Test
+  public void testValidatePModeErrorHandlingReportDeliveryFailuresNotifyProducerMandatory ()
+  {
+    final PModeLegErrorHandling aErrorHandler = PModeLegErrorHandling.createUndefined ();
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    aErrorHandler,
+                                    null,
+                                    null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE)
+                                                .contains ("ErrorHandling.Report.ProcessErrorNotifyProducer is missing")));
+  }
+
+  @Test
+  public void testValidatePModeErrorHandlingReportDeliveryFailuresNotifyProducerWrongValue ()
+  {
+    final PModeLegErrorHandling aErrorHandler = PModeLegErrorHandling.createUndefined ();
+    aErrorHandler.setReportProcessErrorNotifyProducer (false);
+    m_aPMode.setLeg1 (new PModeLeg (PModeLegProtocol.createForDefaultSoapVersion ("http://test.example.org"),
+                                    null,
+                                    aErrorHandler,
+                                    null,
+                                    null));
+    VALIDATOR.validatePMode (m_aPMode, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE)
+                                                .contains ("ErrorHandling.Report.ProcessErrorNotifyProducer should be 'true'")));
+  }
+
+  @Test
+  public void testValidateUserMessageNoMessageInfo ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (null);
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("MessageInfo is missing")));
+  }
+
+  @Test
+  public void testValidateUserMessageNoMessageID ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("MessageInfo/MessageId is missing")));
+  }
+
+  @Test
+  public void testValidateUserMessageRefToMessageIDNotSet ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    aUserMessage.getMessageInfo().setRefToMessageId("RefToMessageId");
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("MessageInfo/RefToMessageId must not be set")));
+  }
+
+  @Test
+  public void testValidateUserMessageNoPartyInfo ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("PartyInfo is missing")));
+  }
+
+  @Test
+  public void testValidateUserMessageNoCollaborationInfo ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("CollaborationInfo is missing")));
+  }
+
+  @Test
+  public void testValidateUserMessageNoCollaborationInfoAgreementRef ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    aUserMessage.setCollaborationInfo (new Ebms3CollaborationInfo ());
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("CollaborationInfo/AgreementRef must be set!")));
+  }
+
+  @Test
+  public void testValidateUserMessageEmptyCollaborationInfoAgreementRef ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    Ebms3CollaborationInfo collaborationInfo = new Ebms3CollaborationInfo ();
+    collaborationInfo.setAgreementRef ("");
+    aUserMessage.setCollaborationInfo (collaborationInfo);
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("CollaborationInfo/AgreementRef value is missing")));
+  }
+
+  @Test
+  public void testValidateUserMessageWrongCollaborationInfoAgreementRef ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    Ebms3CollaborationInfo collaborationInfo = new Ebms3CollaborationInfo ();
+    collaborationInfo.setAgreementRef ("AgreementRef");
+    aUserMessage.setCollaborationInfo (collaborationInfo);
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("CollaborationInfo/AgreementRef value must equal " + BDEWPMode.DEFAULT_AGREEMENT_ID)));
+  }
+
+  @Test
+  public void testValidateUserMessageWrongCollaborationInfoAgreementRefPMode ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    Ebms3CollaborationInfo collaborationInfo = new Ebms3CollaborationInfo ();
+    Ebms3AgreementRef agreementRef = new Ebms3AgreementRef ();
+    agreementRef.setPmode("PModeId");
+    collaborationInfo.setAgreementRef(agreementRef);
+    aUserMessage.setCollaborationInfo (collaborationInfo);
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("CollaborationInfo/PMode must not be set!")));
+  }
+
+  @Test
+  public void testValidateUserMessageWrongCollaborationInfoAgreementRefType ()
+  {
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setMessageInfo (new Ebms3MessageInfo ());
+    Ebms3CollaborationInfo collaborationInfo = new Ebms3CollaborationInfo ();
+    Ebms3AgreementRef agreementRef = new Ebms3AgreementRef ();
+    agreementRef.setType("Type");
+    collaborationInfo.setAgreementRef(agreementRef);
+    aUserMessage.setCollaborationInfo (collaborationInfo);
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("CollaborationInfo/Type must not be set!")));
+  }
+
+  @Test
+  public void testValidateUserMessageMoreThanOnePartyID ()
+  {
+    final Ebms3PartyId aFirstId = MessageHelperMethods.createEbms3PartyId ("type", "value");
+    final Ebms3PartyId aSecondId = MessageHelperMethods.createEbms3PartyId ("type2", "value2");
+
+    final Ebms3From aFromPart = new Ebms3From ();
+    aFromPart.addPartyId (aFirstId);
+    aFromPart.addPartyId (aSecondId);
+    final Ebms3To aToPart = new Ebms3To ();
+    aToPart.addPartyId (aFirstId);
+    aToPart.addPartyId (aSecondId);
+    final Ebms3PartyInfo aPartyInfo = new Ebms3PartyInfo ();
+    aPartyInfo.setFrom (aFromPart);
+    aPartyInfo.setTo (aToPart);
+
+    final Ebms3UserMessage aUserMessage = new Ebms3UserMessage ();
+    aUserMessage.setPartyInfo (aPartyInfo);
+
+    VALIDATOR.validateUserMessage (aUserMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("must contain no more than one PartyID")));
+  }
+
+  @Test
+  public void testValidateSignalMessageNoMessageID ()
+  {
+    final Ebms3SignalMessage aSignalMessage = new Ebms3SignalMessage ();
+    aSignalMessage.setMessageInfo (new Ebms3MessageInfo ());
+    VALIDATOR.validateSignalMessage (aSignalMessage, m_aErrorList);
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("MessageInfo/MessageId is missing")));
+  }
+
+}

--- a/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/BDEWPModeTest.java
+++ b/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/BDEWPModeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.profile.bdew;
+
+import com.helger.phase4.model.pmode.IPModeIDProvider;
+import com.helger.phase4.model.pmode.PMode;
+import com.helger.photon.app.mock.PhotonAppWebTestRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test class for class {@link BDEWPMode}.
+ *
+ * @author Gregor Scholtysik
+ */
+public final class BDEWPModeTest
+{
+  @ClassRule
+  public static final PhotonAppWebTestRule s_aRule = new PhotonAppWebTestRule ();
+
+  @Test
+  public void testBDEWPMode ()
+  {
+    final PMode aPMode = BDEWPMode.createBDEWPMode("TestInitiator",
+                                                        BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW,
+                                                        "TestResponder",
+                                                        BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW,
+                                                        "https://test.example.org",
+                                                        IPModeIDProvider.DEFAULT_DYNAMIC,
+                                                        false);
+    assertNotNull (aPMode);
+  }
+}

--- a/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/SPITest.java
+++ b/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/SPITest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Gregor Scholtysik (www.soptim.de)
+ * gregor[dot]scholtysik[at]soptim[dot]de
+ *
+ * Copyright (C) 2021-2023 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.profile.bdew;
+
+import com.helger.commons.mock.SPITestHelper;
+import org.junit.Test;
+
+/**
+ * Test SPI definitions
+ *
+ * @author Gregor Scholtysik
+ */
+public final class SPITest
+{
+  @Test
+  public void testBasic () throws Exception
+  {
+    SPITestHelper.testIfAllSPIImplementationsAreValid ();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,11 @@
       </dependency>
       <dependency>
         <groupId>com.helger.phase4</groupId>
+        <artifactId>phase4-profile-bdew</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.helger.phase4</groupId>
         <artifactId>phase4-profile-cef</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -304,6 +309,11 @@
       </dependency>
       <dependency>
         <groupId>com.helger.phase4</groupId>
+        <artifactId>phase4-bdew-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.helger.phase4</groupId>
         <artifactId>phase4-entsog-client</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -333,6 +343,7 @@
       </activation>
       <modules>
         <module>phase4-lib</module>
+        <module>phase4-profile-bdew</module>
         <module>phase4-profile-bpc</module>
         <module>phase4-profile-cef</module>
         <module>phase4-profile-eespa</module>
@@ -342,6 +353,7 @@
         <module>phase4-server-webapp</module>
         <module>phase4-dynamic-discovery</module>
         <module>phase4-cef-client</module>
+        <module>phase4-bdew-client</module>
         <module>phase4-entsog-client</module>
         <module>phase4-eudamed-client</module>
         <module>phase4-peppol-client</module>
@@ -357,6 +369,7 @@
       </activation>
       <modules>
         <module>phase4-lib</module>
+        <module>phase4-profile-bdew</module>
         <module>phase4-profile-bpc</module>
         <module>phase4-profile-cef</module>
         <module>phase4-profile-eespa</module>
@@ -366,6 +379,7 @@
         <module>phase4-server-webapp</module>
         <module>phase4-dynamic-discovery</module>
         <module>phase4-cef-client</module>
+        <module>phase4-bdew-client</module>
         <module>phase4-entsog-client</module>
         <module>phase4-eudamed-client</module>
         <module>phase4-peppol-client</module>


### PR DESCRIPTION
Created a BDEW profile and BDEW client, see https://github.com/phax/phase4/discussions/105

Using the profile as-is won't work yet since the PMode's key encryption algorithm is set to `ECryptoKeyEncryptionAlgorithm.ECDH_ES_KEYWRAP_AES_128`, which will produce an error within WSS4J (as it's not supported directly and needs to be worked around).

BDEW specific payload params (`BDEWPayloadParams`) are implemented supporting the fields `BDEWDocumentType`, `BDEWDocumentDate`, `BDEWDocumentNo`, `BDEWFulfillmentDate`, `BDEWSubjectPartyID` and `BDEWSubjectPartyRole`.

The appropriate BDEW services, actions and party types are also implemented in the `BDEWPMode` class.

This is a first draft which likely creates the necesary metadata as specified by the AS4 BDEW profile. Further tests may reveal that minor adjustments could be necessary.

Apart from the two new modules only little changes were made to one other module, _phase4-lib_:

`AS4CryptParams#m_sKeyEncAlgorithm` was converted to a newly introduced enumeration, `ECryptoKeyEncryptionAlgorithm` with three new algorithms for ECDH-ES Keywrap 128, 192 and 256.

Feel free to adjust all the copyright headers as necessary, I'm not sure about the conventions used in this project.