### PR TITLE
IAS4ProfileValidator: new validation, relates to #182

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/messaging/IAS4IncomingMessageMetadata.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/messaging/IAS4IncomingMessageMetadata.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phase4.messaging;
 
+import java.security.cert.X509Certificate;
 import java.time.OffsetDateTime;
 
 import javax.annotation.CheckForSigned;
@@ -150,6 +151,25 @@ public interface IAS4IncomingMessageMetadata
   default boolean hasRemoteUser ()
   {
     return StringHelper.hasText (getRemoteUser ());
+  }
+
+  /**
+   * Returns the TLS certificates presented by the remote client to
+   * authenticate itself.
+   *
+   * @return an array containing a chain of X509Certificate objects
+   */
+  @Nullable
+  X509Certificate[] getRemoteTlsCerts ();
+
+  /**
+   * @return <code>true</code> if the remote TLS certificate chain with at least
+   * a single certificate is present, <code>false</code> if not.
+   * @see #getRemoteUser()
+   */
+  default boolean hasRemoteTlsCerts ()
+  {
+    return getRemoteTlsCerts () != null && getRemoteTlsCerts ().length > 0;
   }
 
   /**

--- a/phase4-lib/src/main/java/com/helger/phase4/profile/IAS4ProfileValidator.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/profile/IAS4ProfileValidator.java
@@ -17,12 +17,16 @@
 package com.helger.phase4.profile;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.helger.commons.error.list.ErrorList;
 import com.helger.phase4.ebms3header.Ebms3SignalMessage;
 import com.helger.phase4.ebms3header.Ebms3UserMessage;
+import com.helger.phase4.messaging.IAS4IncomingMessageMetadata;
 import com.helger.phase4.model.pmode.IPMode;
 import com.helger.phase4.v3.ChangeV3;
+
+import java.security.cert.X509Certificate;
 
 /**
  * Generic AS4 profile validator
@@ -42,6 +46,24 @@ public interface IAS4ProfileValidator
    */
   @ChangeV3 ("add parameter if for UserMessage or SignalMessage")
   default void validatePMode (@Nonnull final IPMode aPMode, @Nonnull final ErrorList aErrorList)
+  {}
+
+  /**
+   * Validation method
+   *
+   * @param aUserMsg
+   *        The message to use for comparison. May not be <code>null</code>.
+   * @param aSigCert
+   *        The signature certificate used to sign the message. Can be <code>null</code>.
+   * @param aMessageMetadata
+   *        Metadata of the message containing the TLS client certificate. May not be <code>null</code>.
+   * @param aErrorList
+   *        The error list to be filled. May not be <code>null</code>.
+   */
+  default void validateInitiatorIdentity(@Nonnull final Ebms3UserMessage aUserMsg,
+                                         @Nullable X509Certificate aSigCert,
+                                         @Nonnull IAS4IncomingMessageMetadata aMessageMetadata,
+                                         @Nonnull final ErrorList aErrorList)
   {}
 
   /**

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4IncomingHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4IncomingHandler.java
@@ -570,7 +570,8 @@ public final class AS4IncomingHandler
                                                      @Nonnull final ESoapVersion eSoapVersion,
                                                      @Nonnull final ICommonsList <WSS4JAttachment> aIncomingAttachments,
                                                      @Nonnull final IAS4IncomingProfileSelector aAS4ProfileSelector,
-                                                     @Nonnull final ICommonsList <Ebms3Error> aErrorMessagesTarget) throws Phase4Exception
+                                                     @Nonnull final ICommonsList <Ebms3Error> aErrorMessagesTarget,
+                                                     @Nonnull final IAS4IncomingMessageMetadata aMessageMetadata) throws Phase4Exception
   {
     ValueEnforcer.notNull (aResHelper, "ResHelper");
     ValueEnforcer.notNull (aLocale, "Locale");
@@ -691,6 +692,7 @@ public final class AS4IncomingHandler
             final ErrorList aErrorList = new ErrorList ();
             aValidator.validatePMode (aPMode, aErrorList);
             aValidator.validateUserMessage (aEbmsUserMessage, aErrorList);
+            aValidator.validateInitiatorIdentity(aEbmsUserMessage, aState.getUsedCertificate(), aMessageMetadata, aErrorList);
             if (aErrorList.isNotEmpty ())
             {
               throw new Phase4Exception ("Error validating incoming AS4 UserMessage with the profile " +
@@ -811,7 +813,8 @@ public final class AS4IncomingHandler
                                                           eSoapVersion,
                                                           aIncomingAttachments,
                                                           aAS4ProfileSelector,
-                                                          aErrorMessages);
+                                                          aErrorMessages,
+                                                          aMessageMetadata);
 
       if (aState.isSoapHeaderElementProcessingSuccessful ())
       {

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4IncomingMessageMetadata.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4IncomingMessageMetadata.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phase4.servlet;
 
+import java.security.cert.X509Certificate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -51,6 +52,7 @@ public class AS4IncomingMessageMetadata implements IAS4IncomingMessageMetadata
   private String m_sRemoteHost;
   private int m_nRemotePort = -1;
   private String m_sRemoteUser;
+  private X509Certificate[] m_aRemoteTlsCerts;
   private final ICommonsList <Cookie> m_aCookies = new CommonsArrayList <> ();
   private String m_sRequestMessageID;
 
@@ -186,6 +188,26 @@ public class AS4IncomingMessageMetadata implements IAS4IncomingMessageMetadata
   public AS4IncomingMessageMetadata setRemoteUser (@Nullable final String sRemoteUser)
   {
     m_sRemoteUser = sRemoteUser;
+    return this;
+  }
+
+  @Nullable
+  public X509Certificate[] getRemoteTlsCerts ()
+  {
+    return m_aRemoteTlsCerts;
+  }
+
+  /**
+   * Set the remote TLS certificates to be used.
+   *
+   * @param aRemoteTlsCerts
+   *        The TLS certificates the remote client presented during the handshake. May be <code>null</code>.
+   * @return this for chaining
+   */
+  @Nonnull
+  public AS4IncomingMessageMetadata setRemoteTlsCerts (@Nullable final X509Certificate[] aRemoteTlsCerts)
+  {
+    m_aRemoteTlsCerts = aRemoteTlsCerts;
     return this;
   }
 

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4RequestHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4RequestHandler.java
@@ -1307,7 +1307,8 @@ public class AS4RequestHandler implements AutoCloseable
                                                                            eSoapVersion,
                                                                            aIncomingAttachments,
                                                                            m_aIncomingProfileSelector,
-                                                                           aErrorMessagesTarget);
+                                                                           aErrorMessagesTarget,
+                                                                           m_aMessageMetadata);
 
     // Evaluate the results of processing
     final IPMode aPMode = aState.getPMode ();


### PR DESCRIPTION
relates to #182

I added a new validation in `IAS4ProfileValidator` (with empty default implementation) and implemented it for `BDEWCompatibilityValidator`. It checks if the initiator party ID and the market participant ID in the OU part of the signature and client TLS certificates match. I obtained the client TLS certificate from the `ServletRequest` in `AS4XServletHandler` and saved it in `IAS4IncomingMessageMetadata`. 