### PR TITLE
BDEWCompatibilityValidator: extended validation of PMode

### DIFF
--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWPMode.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWPMode.java
@@ -44,6 +44,8 @@ import com.helger.phase4.model.pmode.leg.PModeLegProtocol;
 import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
 import com.helger.phase4.wss.EWSSVersion;
 
+import java.util.Set;
+
 /**
  * PMode creation code.
  *
@@ -211,5 +213,16 @@ public final class BDEWPMode
       MetaAS4Manager.getPModeMgr ().createOrUpdatePMode (aPMode);
     }
     return aPMode;
+  }
+
+  public static Set<String> getServices ()
+  {
+    return Set.of(SERVICE_TEST, SERVICE_PATH_SWITCH, SERVICE_MARKTPROZESSE, SERVICE_FAHRPLAN,
+                  SERVICE_REDISPATCH_2_0, SERVICE_KWEP, SERVICE_SOGL);
+  }
+
+  public static Set<String> getActions ()
+  {
+    return Set.of(ACTION_DEFAULT, ACTION_TEST_SERVICE, ACTION_REQUEST_SWITCH, ACTION_CONFIRM_SWITCH);
   }
 }


### PR DESCRIPTION
I extended the PMode validation in BDEWCompatibilityValidator to cover the most BDEW PMode requirements that were not yet included at this point. (see https://www.edi-energy.de/index.php?id=38&tx_bdew_bdew%5Buid%5D=2091&tx_bdew_bdew%5Baction%5D=download&tx_bdew_bdew%5Bcontroller%5D=Dokument&cHash=c3338aa8cb55e5946a1b0d1dbfdc2e0a, p. 21 - 24)

In detail :

- PMode[1].BusinessInfo.*
- PMode[1].ReceptionAwareness.* 
- PMode[1].Security.X509.Encryption.MinimalStrength
- PMode.Initiator.Role / PMode.Responder.Role
- PMode.Agreement
- minor adjustment for PMode[1].Protocol