### PR TITLE
BDEWCompatibilityValidator: extended validation of UserMessages

### DIFF
--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidator.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidator.java
@@ -515,7 +515,7 @@ public class BDEWCompatibilityValidator implements IAS4ProfileValidator
           aErrorList.add (_createError ("PartyInfo/From must contain no more than one PartyID"));
         }
 
-        if (StringHelper.hasNoText (aFrom.getRole ()) || !aFrom.getRole ().equals (CAS4.DEFAULT_INITIATOR_URL))
+        if (!CAS4.DEFAULT_INITIATOR_URL.equals (aFrom.getRole ()))
         {
           aErrorList.add (_createError ("PartyInfo/From/Role must be set to '" + CAS4.DEFAULT_INITIATOR_URL + "'"));
         }
@@ -533,7 +533,7 @@ public class BDEWCompatibilityValidator implements IAS4ProfileValidator
           aErrorList.add (_createError ("PartyInfo/To must contain no more than one PartyID"));
         }
 
-        if (StringHelper.hasNoText (aTo.getRole ()) || !aTo.getRole ().equals (CAS4.DEFAULT_RESPONDER_URL))
+        if (!CAS4.DEFAULT_RESPONDER_URL.equals (aTo.getRole ()))
         {
           aErrorList.add (_createError ("PartyInfo/To/Role must be set to '" + CAS4.DEFAULT_RESPONDER_URL + "'"));
         }


### PR DESCRIPTION
I extended the validation of UserMessages in BDEWCompatibilityValidator to cover the following requirements of the BDEW AS4 profile:

(see https://www.edi-energy.de/index.php?id=38&tx_bdew_bdew%5Buid%5D=2091&tx_bdew_bdew%5Baction%5D=download&tx_bdew_bdew%5Bcontroller%5D=Dokument&cHash=c3338aa8cb55e5946a1b0d1dbfdc2e0a, chapters 2.3.1.2.1, 2.3.1.2.2 and 2.3.1.2.3)

* PartyInfo/From/Role (static value)
* PartyInfo/To/Role (static value)
* CollaborationInfo/Service (a set of static values)
* CollaborationInfo/Action (a set of static values)

Among tests for the new validations, I added two unit tests that test the "happy flow" for PMode and UserMessages.