### PR TITLE
Log info message only if profile does not invoke custom handlers

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4IncomingHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4IncomingHandler.java
@@ -814,7 +814,7 @@ public final class AS4IncomingHandler
 
       final boolean bIsPingMessage = AS4Helper.isPingMessage (aPMode);
       aState.setPingMessage (bIsPingMessage);
-      if (bIsPingMessage)
+      if (bIsPingMessage && (aProfile == null || !aProfile.isInvokeSPIForPingMessage()))
         LOGGER.info ("Received an AS4 Ping message - meaning it will NOT be handled by the custom handlers.");
     }
 

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4RequestHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4RequestHandler.java
@@ -1372,7 +1372,7 @@ public class AS4RequestHandler implements AutoCloseable
     // * No errors so far (sign, encrypt, ...)
     // * Valid PMode
     // * Exactly one UserMessage or SignalMessage
-    // * No ping/test message
+    // * If Ping/test message then only if profile should invoke SPI
     // * No Duplicate message ID
     boolean bCanInvokeSPIs = true;
     if (aErrorMessagesTarget.isNotEmpty ())

--- a/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4RequestHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/servlet/AS4RequestHandler.java
@@ -1372,7 +1372,7 @@ public class AS4RequestHandler implements AutoCloseable
     // * No errors so far (sign, encrypt, ...)
     // * Valid PMode
     // * Exactly one UserMessage or SignalMessage
-    // * If Ping/test message then only if profile should invoke SPI
+    // * If ping/test message then only if profile should invoke SPI
     // * No Duplicate message ID
     boolean bCanInvokeSPIs = true;
     if (aErrorMessagesTarget.isNotEmpty ())


### PR DESCRIPTION
The info message should not be logged in the BDEW profile with `bInvokeSPIForPingMessage = true`.