### PR TITLE
Adding "Bahnstrom" (DB Energie) market partner IDs as valid code type

### DIFF
--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/AS4BDEWProfileRegistarSPI.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/AS4BDEWProfileRegistarSPI.java
@@ -52,6 +52,8 @@ public final class AS4BDEWProfileRegistarSPI implements IAS4ProfileRegistrarSPI
       return BDEWPMode.BDEW_PARTY_ID_TYPE_BDEW;
     if (sID.startsWith ("98"))
       return BDEWPMode.BDEW_PARTY_ID_TYPE_DVGW;
+    if (sID.startsWith ("19"))
+      return BDEWPMode.BDEW_PARTY_ID_TYPE_BAHN;
     return BDEWPMode.BDEW_PARTY_ID_TYPE_GLN;
   }
 

--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWPMode.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWPMode.java
@@ -62,6 +62,7 @@ public final class BDEWPMode
   public static final String BDEW_PARTY_ID_TYPE_GLN = "urn:oasis:names:tc:ebcore:partyid-type:iso6523:0088";
   public static final String BDEW_PARTY_ID_TYPE_BDEW = "urn:oasis:names:tc:ebcore:partyid-type:unregistered:BDEW";
   public static final String BDEW_PARTY_ID_TYPE_DVGW = "urn:oasis:names:tc:ebcore:partyid-type:unregistered:DVGW";
+  public static final String BDEW_PARTY_ID_TYPE_BAHN = "urn:oasis:names:tc:ebcore:partyid-type:unregistered:BAHN";
 
   public static final String SERVICE_TEST = "http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/service";
   public static final String SERVICE_PATH_SWITCH = "https://www.bdew.de/as4/communication/services/pathSwitch";


### PR DESCRIPTION
Adding `urn:oasis:names:tc:ebcore:partyid-type:unregistered:BAHN` as valid market participant code types.

The SM-PKI Root CA already accepts such IDs:

![grafik](https://github.com/user-attachments/assets/411ce857-3108-4f87-9ca7-1f9569ba8fee)

-> https://www.telesec.de/assets/downloads/Smart-Metering-PKI/ChangeLog_Root.pdf

Currently the Federal Network Agency (Bundesnetzagentur) is consulting the market changes for April 2025 (-> https://www.bundesnetzagentur.de/DE/Beschlusskammern/BK06/BK6_83_Zug_Mess/835_mitteilungen_datenformate/Mitteilung_44/Mitteilung_Nr_44.html?nn=660086). It is planned to officially add Bahnstrom to the BDEW AS4 profile.

(Also some other minor changes are likely planned for April 2025, the final documents will be published in a few weeks/months after the consultation has finished)