### PR TITLE
Sywong2000 patch fix missing ref to message id non repudiation receipt

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/client/AS4ClientReceiptMessage.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/client/AS4ClientReceiptMessage.java
@@ -153,7 +153,8 @@ public class AS4ClientReceiptMessage extends AbstractAS4ClientSignalMessage <AS4
                                                                     sMessageID,
                                                                     m_aEbms3UserMessage,
                                                                     m_aSoapDocument,
-                                                                    m_bNonRepudiation);
+                                                                    m_bNonRepudiation,
+                                                                    getRefToMessageID());
 
     if (aCallback != null)
       aCallback.onAS4Message (aReceiptMsg);

--- a/phase4-lib/src/main/java/com/helger/phase4/model/message/AS4ReceiptMessage.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/message/AS4ReceiptMessage.java
@@ -89,7 +89,8 @@ public class AS4ReceiptMessage extends AbstractAS4Message <AS4ReceiptMessage>
                                           @Nonnull @Nonempty final String sMessageID,
                                           @Nullable final Ebms3UserMessage aEbms3UserMessageToRespond,
                                           @Nullable final Node aSoapDocument,
-                                          final boolean bShouldUseNonRepudiation)
+                                          final boolean bShouldUseNonRepudiation,
+                                          @Nullable final String sRefToMessageID)
   {
     // Only for signed messages
     final ICommonsList <ReferenceType> aDSRefs = MessageHelperMethods.getAllDSigReferences (aSoapDocument);
@@ -100,7 +101,7 @@ public class AS4ReceiptMessage extends AbstractAS4Message <AS4ReceiptMessage>
     {
       // Always use "now" as date time
       final String sRefToMsgID = aEbms3UserMessageToRespond != null ? aEbms3UserMessageToRespond.getMessageInfo ()
-                                                                                                .getMessageId () : null;
+                                                                                                .getMessageId () : sRefToMessageID;
       aSignalMessage.setMessageInfo (MessageHelperMethods.createEbms3MessageInfo (sMessageID, sRefToMsgID));
     }
 


### PR DESCRIPTION
Upon sending a non-repudiation Receipt, the RefToMessageId is not being outputted even the AS4ClientReceiptMessage.setRefToMessageID() is called. This patch is to fix the behavior.