### PR TITLE
BDEWApplicationReference from RzÜ 2.3

### DIFF
--- a/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWSender.java
+++ b/phase4-bdew-client/src/main/java/com/helger/phase4/bdew/Phase4BDEWSender.java
@@ -228,6 +228,9 @@ public final class Phase4BDEWSender
         if (m_aPayloadParams.getSubjectPartyRole () != null)
           aPayloadAttachment.customPartProperties ()
                             .put ("BDEWSubjectPartyRole", m_aPayloadParams.getSubjectPartyRole ());
+        if (m_aPayloadParams.getApplicationReference () != null)
+          aPayloadAttachment.customPartProperties ()
+                            .put ("BDEWApplicationReference", m_aPayloadParams.getApplicationReference ());
       }
       return aPayloadAttachment;
     }
@@ -259,6 +262,7 @@ public final class Phase4BDEWSender
     private LocalDate m_aFulfillmentDate;
     private String m_sSubjectPartyID;
     private String m_sSubjectPartyRole;
+    private String m_sApplicationReference;
 
     /**
      * @return BDEW payload document type for payload identifier
@@ -423,6 +427,31 @@ public final class Phase4BDEWSender
       return this;
     }
 
+
+    /**
+     * @return BDEW payload application reference for payload identifier
+     *         <code>BDEWApplicationReference</code>
+     */
+    @Nullable
+    public String getApplicationReference ()
+    {
+      return m_sApplicationReference;
+    }
+
+    /**
+     * BDEW payload application reference
+     *
+     * @param sApplicationReference
+     *        Application reference to use. May be <code>null</code>.
+     * @return this for chaining
+     */
+    @Nonnull
+    public BDEWPayloadParams setApplicationReference (@Nullable final String sApplicationReference)
+    {
+      m_sApplicationReference = sApplicationReference;
+      return this;
+    }
+
     @Override
     public String toString ()
     {
@@ -432,6 +461,7 @@ public final class Phase4BDEWSender
                                          .append ("FulfillmentDate", m_aFulfillmentDate)
                                          .append ("SubjectPartyID", m_sSubjectPartyID)
                                          .append ("SubjectPartyRole", m_sSubjectPartyRole)
+                                         .append ("ApplicationReference", m_sApplicationReference)
                                          .getToString ();
     }
   }


### PR DESCRIPTION
Adding BDEWApplicationReference part property from RzÜ 2.3.

![grafik](https://github.com/user-attachments/assets/83381c68-a0cc-4474-ae9b-3fad8c3a8f24)

https://www.edi-energy.de/index.php?id=38&tx_bdew_bdew%5Buid%5D=2559&tx_bdew_bdew%5Baction%5D=download&tx_bdew_bdew%5Bcontroller%5D=Dokument&cHash=cf1601eaa1635796d81d8c966c188cca