### PR TITLE
Fix: Removed "duplicated" ICryptoSessionKeyProvider instances for AES keys

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/crypto/ICryptoSessionKeyProvider.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/crypto/ICryptoSessionKeyProvider.java
@@ -27,7 +27,7 @@ import org.apache.wss4j.common.util.KeyUtils;
 public interface ICryptoSessionKeyProvider
 {
   /**
-   * Get or create a new symmetric session key. This method may only throws
+   * Get or create a new symmetric session key. This method may only throw
    * unchecked exceptions.
    *
    * @return A new session key. Must not be <code>null</code>.
@@ -35,6 +35,9 @@ public interface ICryptoSessionKeyProvider
   @Nonnull
   SecretKey getSessionKey ();
 
+  /**
+   * Session key provider for AES-128 keys that can be used e.g. for AES-128-CBC or AES-128-GCM
+   */
   ICryptoSessionKeyProvider INSTANCE_RANDOM_AES_128 = () -> {
     try
     {
@@ -47,18 +50,9 @@ public interface ICryptoSessionKeyProvider
     }
   };
 
-  ICryptoSessionKeyProvider INSTANCE_RANDOM_AES_128_GCM = () -> {
-    try
-    {
-      final KeyGenerator aKeyGen = KeyUtils.getKeyGenerator (WSS4JConstants.AES_128_GCM);
-      return aKeyGen.generateKey ();
-    }
-    catch (final WSSecurityException ex)
-    {
-      throw new IllegalStateException ("Failed to create session key (AES-128-GCM)", ex);
-    }
-  };
-
+  /**
+   * Session key provider for AES-256 keys that can be used e.g. for AES-256-CBC or AES-256-GCM
+   */
   ICryptoSessionKeyProvider INSTANCE_RANDOM_AES_256 = () -> {
     try
     {
@@ -71,15 +65,4 @@ public interface ICryptoSessionKeyProvider
     }
   };
 
-  ICryptoSessionKeyProvider INSTANCE_RANDOM_AES_256_GCM = () -> {
-    try
-    {
-      final KeyGenerator aKeyGen = KeyUtils.getKeyGenerator (WSS4JConstants.AES_256_GCM);
-      return aKeyGen.generateKey ();
-    }
-    catch (final WSSecurityException ex)
-    {
-      throw new IllegalStateException ("Failed to create session key (AES-256-GCM)", ex);
-    }
-  };
 }


### PR DESCRIPTION
This basically reverts the change https://github.com/phax/phase4/commit/90485ce0170a2995e5c3e817d516446969bedcfa.

AES keys for AES with CBC op mode and AES with GCM op mode are the same.