### PR TITLE
Unused BC dependencies removed

### DIFF
--- a/phase4-dbnalliance-client/pom.xml
+++ b/phase4-dbnalliance-client/pom.xml
@@ -91,12 +91,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctls-jdk18on</artifactId>
-      <version>${bctls.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.helger.commons</groupId>
       <artifactId>ph-unittest-support-ext</artifactId>
       <scope>test</scope>

--- a/phase4-euctp-client/pom.xml
+++ b/phase4-euctp-client/pom.xml
@@ -82,12 +82,6 @@
       <artifactId>ph-unittest-support-ext</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctls-jdk18on</artifactId>
-      <version>${bctls.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/phase4-lib/pom.xml
+++ b/phase4-lib/pom.xml
@@ -39,10 +39,6 @@
   </licenses>
   <dependencies>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcjmail-jdk18on</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.wss4j</groupId>
       <artifactId>wss4j-ws-security-dom</artifactId>
     </dependency>


### PR DESCRIPTION
Unused BC dependencies removed

- bcjmail -> not needed in general
- bctls -> only needed for BDEW profile tests