### PR TITLE
Handle SOAP faults in responses

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/client/AbstractAS4Client.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/client/AbstractAS4Client.java
@@ -56,6 +56,7 @@ import com.helger.phase4.model.message.MessageHelperMethods;
 import com.helger.phase4.model.pmode.IPMode;
 import com.helger.phase4.model.pmode.PModeReceptionAwareness;
 import com.helger.phase4.model.pmode.leg.PModeLeg;
+import com.helger.phase4.model.soapfault.AS4SoapFaultException;
 import com.helger.phase4.util.AS4ResourceHelper;
 
 import jakarta.mail.MessagingException;
@@ -556,15 +557,24 @@ public abstract class AbstractAS4Client <IMPLTYPE extends AbstractAS4Client <IMP
     // Capture the remote TLS server certificates of the (last) successful
     // HTTPS exchange so they can be surfaced via AS4ClientSentMessage
     final Wrapper <ICommonsList <X509Certificate>> aRemoteTlsPeerCertsHolder = new Wrapper <> ();
-    final T aResponseContent = m_aHttpPoster.sendGenericMessageWithRetries (sURL,
-                                                                            aBuiltHttpHeaders,
-                                                                            aBuiltEntity,
-                                                                            sMessageID,
-                                                                            m_aHttpRetrySettings,
-                                                                            aRealResponseHandler,
-                                                                            aOutgoingDumper,
-                                                                            aRetryCallback,
-                                                                            aRemoteTlsPeerCertsHolder::set);
+    final T aResponseContent;
+    try
+    {
+      aResponseContent = m_aHttpPoster.sendGenericMessageWithRetries (sURL,
+                                                                      aBuiltHttpHeaders,
+                                                                      aBuiltEntity,
+                                                                      sMessageID,
+                                                                      m_aHttpRetrySettings,
+                                                                      aRealResponseHandler,
+                                                                      aOutgoingDumper,
+                                                                      aRetryCallback,
+                                                                      aRemoteTlsPeerCertsHolder::set);
+    }
+    catch (final AS4SoapFaultException ex)
+    {
+      // Attach the AS4 Message ID of the sent message for downstream evaluation
+      throw ex.setSentMessageID (sMessageID);
+    }
     final AS4ClientSentMessage <T> ret = new AS4ClientSentMessage <> (aBuiltMsg,
                                                                       aRemoteTlsPeerCertsHolder.get (),
                                                                       aStatusLineKeeper.get (),

--- a/phase4-lib/src/main/java/com/helger/phase4/incoming/AS4IncomingHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/incoming/AS4IncomingHandler.java
@@ -167,20 +167,6 @@ public final class AS4IncomingHandler
       aIncomingMessageMetadata.getResponseHttpStatusCode () >= CHttp.HTTP_MULTIPLE_CHOICES;
   }
 
-  private static boolean _isSoapFault (@NonNull final Document aSoapDocument, @NonNull final ESoapVersion eSoapVersion)
-  {
-    final Node aBody = XMLHelper.getFirstChildElementOfName (aSoapDocument.getDocumentElement (),
-                                                             eSoapVersion.getNamespaceURI (),
-                                                             eSoapVersion.getBodyElementName ());
-    if (aBody == null)
-      return false;
-
-    final Element aBodyFirst = XMLHelper.getFirstChildElement (aBody);
-    return aBodyFirst != null &&
-      "Fault".equals (aBodyFirst.getLocalName ()) &&
-      eSoapVersion.getNamespaceURI ().equals (aBodyFirst.getNamespaceURI ());
-  }
-
   public static void parseAS4Message (@NonNull final IAS4IncomingAttachmentFactory aIAF,
                                       @NonNull @WillNotClose final AS4ResourceHelper aResHelper,
                                       @NonNull final IAS4IncomingMessageMetadata aIncomingMessageMetadata,

--- a/phase4-lib/src/main/java/com/helger/phase4/messaging/http/BasicHttpPoster.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/messaging/http/BasicHttpPoster.java
@@ -55,6 +55,7 @@ import com.helger.phase4.dump.AS4DumpManager;
 import com.helger.phase4.dump.IAS4OutgoingDumper;
 import com.helger.phase4.logging.Phase4LoggerFactory;
 import com.helger.phase4.messaging.EAS4MessageMode;
+import com.helger.phase4.model.soapfault.AS4SoapFaultException;
 import com.helger.phase4.util.MultiOutputStream;
 
 /**
@@ -496,6 +497,14 @@ public class BasicHttpPoster implements IHttpPoster
                                        aDumpingEntity,
                                        aResponseHandler,
                                        aRemoteTlsPeerCertConsumer);
+          }
+          catch (final AS4SoapFaultException ex)
+          {
+            // A SOAP Fault with a permanent disposition must never be retried
+            LOGGER.warn ("Received a permanent SOAP Fault for message with ID '" +
+                         sMessageID +
+                         "' - stopping all retries");
+            throw ex;
           }
           catch (final IOException ex)
           {

--- a/phase4-lib/src/main/java/com/helger/phase4/model/EAS4ResponseType.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/EAS4ResponseType.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.id.IHasID;
+import com.helger.base.lang.EnumHelper;
+
+/**
+ * Classification of the synchronous response received for an outgoing AS4 message. The
+ * classification is independent of the HTTP response status code, because non-conforming peers may
+ * e.g. return SOAP Faults with HTTP 200.
+ *
+ * @author Philip Helger
+ * @since 4.6.0
+ */
+public enum EAS4ResponseType implements IHasID <String>
+{
+  /**
+   * An ebMS Signal Message containing a Receipt was received.
+   */
+  RECEIPT ("receipt"),
+  /**
+   * An ebMS Signal Message containing at least one Error was received.
+   */
+  EBMS_ERROR ("ebms-error"),
+  /**
+   * A plain SOAP Fault (SOAP 1.1 or 1.2) was received.
+   */
+  SOAP_FAULT ("soap-fault"),
+  /**
+   * The response body was empty.
+   */
+  EMPTY ("empty"),
+  /**
+   * The response body was not usable SOAP (e.g. an HTML proxy error page) or contained no usable
+   * ebMS message.
+   */
+  UNPARSABLE ("unparsable");
+
+  private final String m_sID;
+
+  EAS4ResponseType (@NonNull @Nonempty final String sID)
+  {
+    m_sID = sID;
+  }
+
+  @NonNull
+  @Nonempty
+  public String getID ()
+  {
+    return m_sID;
+  }
+
+  @Nullable
+  public static EAS4ResponseType getFromIDOrNull (@Nullable final String sID)
+  {
+    return EnumHelper.getFromIDOrNull (EAS4ResponseType.class, sID);
+  }
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFault.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFault.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model.soapfault;
+
+import javax.xml.namespace.QName;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.helger.annotation.concurrent.Immutable;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.base.string.StringHelper;
+import com.helger.base.tostring.ToStringGenerator;
+import com.helger.phase4.model.ESoapVersion;
+import com.helger.xml.XMLHelper;
+import com.helger.xml.serialize.write.XMLWriter;
+
+/**
+ * Immutable, SOAP version aware domain object for a received SOAP Fault. Even though ebMS 3.0 Core
+ * requires ebMS layer faults to be expressed as <code>eb:Error</code> signals, a peer may still
+ * respond with a plain SOAP Fault - this class detects and represents such responses.
+ *
+ * @author Philip Helger
+ * @since 4.6.0
+ */
+@Immutable
+public class AS4SoapFault
+{
+  private final ESoapVersion m_eSoapVersion;
+  private final QName m_aFaultCode;
+  private final QName m_aFaultSubcode;
+  private final String m_sFaultReason;
+  private final String m_sFaultActorRole;
+  private final Element m_aDetailElement;
+  private final String m_sRawXML;
+
+  public AS4SoapFault (@NonNull final ESoapVersion eSoapVersion,
+                       @Nullable final QName aFaultCode,
+                       @Nullable final QName aFaultSubcode,
+                       @Nullable final String sFaultReason,
+                       @Nullable final String sFaultActorRole,
+                       @Nullable final Element aDetailElement,
+                       @NonNull final String sRawXML)
+  {
+    ValueEnforcer.notNull (eSoapVersion, "SoapVersion");
+    ValueEnforcer.notNull (sRawXML, "RawXML");
+    m_eSoapVersion = eSoapVersion;
+    m_aFaultCode = aFaultCode;
+    m_aFaultSubcode = aFaultSubcode;
+    m_sFaultReason = sFaultReason;
+    m_sFaultActorRole = sFaultActorRole;
+    m_aDetailElement = aDetailElement;
+    m_sRawXML = sRawXML;
+  }
+
+  /**
+   * @return The SOAP version the fault was expressed in. This may differ from the SOAP version of
+   *         the conversation. Never <code>null</code>.
+   */
+  @NonNull
+  public ESoapVersion getSoapVersion ()
+  {
+    return m_eSoapVersion;
+  }
+
+  /**
+   * @return The fault code as a {@link QName}. For SOAP 1.1 this is the <code>faultcode</code>
+   *         element content, for SOAP 1.2 the <code>Code/Value</code> element content. May be
+   *         <code>null</code> if it was absent or empty.
+   */
+  @Nullable
+  public QName getFaultCode ()
+  {
+    return m_aFaultCode;
+  }
+
+  public boolean hasFaultCode ()
+  {
+    return m_aFaultCode != null;
+  }
+
+  /**
+   * @return The fault subcode as a {@link QName}. Only ever present for SOAP 1.2
+   *         (<code>Code/Subcode/Value</code>). May be <code>null</code>.
+   */
+  @Nullable
+  public QName getFaultSubcode ()
+  {
+    return m_aFaultSubcode;
+  }
+
+  /**
+   * @return The human readable fault text. For SOAP 1.1 this is the <code>faultstring</code>
+   *         element content, for SOAP 1.2 the first <code>Reason/Text</code> element content. May
+   *         be <code>null</code>.
+   */
+  @Nullable
+  public String getFaultReason ()
+  {
+    return m_sFaultReason;
+  }
+
+  /**
+   * @return The fault actor (SOAP 1.1 <code>faultactor</code>) respectively role (SOAP 1.2
+   *         <code>Role</code>). May be <code>null</code>.
+   */
+  @Nullable
+  public String getFaultActorRole ()
+  {
+    return m_sFaultActorRole;
+  }
+
+  /**
+   * @return The raw detail subtree (SOAP 1.1 <code>detail</code>, SOAP 1.2 <code>Detail</code>).
+   *         May be <code>null</code>.
+   */
+  @Nullable
+  public Element getDetailElement ()
+  {
+    return m_aDetailElement;
+  }
+
+  /**
+   * @return The XML of the full fault response document, primarily meant for dumping. Never
+   *         <code>null</code>.
+   */
+  @NonNull
+  public String getRawXML ()
+  {
+    return m_sRawXML;
+  }
+
+  /**
+   * @return The retry disposition of this fault, based on the fault code. Never <code>null</code>.
+   *         Unknown or absent fault codes are considered {@link EAS4FaultDisposition#TRANSIENT}.
+   */
+  @NonNull
+  public EAS4FaultDisposition getDisposition ()
+  {
+    if (m_aFaultCode != null)
+    {
+      final String sLocalPart = m_aFaultCode.getLocalPart ();
+      // SOAP 1.1 uses "Client" (with eventual dot-separated subcategories like
+      // "Client.Authentication"), SOAP 1.2 uses "Sender"
+      if ("Client".equals (sLocalPart) ||
+        sLocalPart.startsWith ("Client.") ||
+        "Sender".equals (sLocalPart) ||
+        "VersionMismatch".equals (sLocalPart) ||
+        "MustUnderstand".equals (sLocalPart))
+        return EAS4FaultDisposition.PERMANENT;
+    }
+
+    // "Server"/"Receiver" as well as unknown or absent fault codes
+    return EAS4FaultDisposition.TRANSIENT;
+  }
+
+  @Override
+  public String toString ()
+  {
+    return new ToStringGenerator (this).append ("SoapVersion", m_eSoapVersion)
+                                       .appendIfNotNull ("FaultCode", m_aFaultCode)
+                                       .appendIfNotNull ("FaultSubcode", m_aFaultSubcode)
+                                       .appendIfNotNull ("FaultReason", m_sFaultReason)
+                                       .appendIfNotNull ("FaultActorRole", m_sFaultActorRole)
+                                       .appendIfNotNull ("DetailElement", m_aDetailElement)
+                                       .append ("RawXML", m_sRawXML)
+                                       .getToString ();
+  }
+
+  /**
+   * Parse the provided text content as a {@link QName}, resolving an eventually contained namespace
+   * prefix against the namespace context of the provided element.
+   *
+   * @param sValue
+   *        The text content to parse. May be <code>null</code>.
+   * @param aContextElement
+   *        The element in whose namespace context the prefix is resolved. May not be
+   *        <code>null</code>.
+   * @return <code>null</code> if the text content is empty.
+   */
+  @Nullable
+  private static QName _parseQName (@Nullable final String sValue, @NonNull final Element aContextElement)
+  {
+    final String sRealValue = StringHelper.trim (sValue);
+    if (StringHelper.isEmpty (sRealValue))
+      return null;
+
+    final int nColonIndex = sRealValue.indexOf (':');
+    if (nColonIndex < 0)
+    {
+      // No prefix - resolve the default namespace
+      final String sNamespaceURI = aContextElement.lookupNamespaceURI (null);
+      return sNamespaceURI == null ? new QName (sRealValue) : new QName (sNamespaceURI, sRealValue);
+    }
+
+    final String sPrefix = sRealValue.substring (0, nColonIndex);
+    final String sLocalPart = sRealValue.substring (nColonIndex + 1);
+    final String sNamespaceURI = aContextElement.lookupNamespaceURI (sPrefix);
+    if (sNamespaceURI == null)
+    {
+      // Unresolvable prefix - keep the local part only
+      return new QName (sLocalPart);
+    }
+    return new QName (sNamespaceURI, sLocalPart, sPrefix);
+  }
+
+  @Nullable
+  private static String _getChildElementTextContent (@NonNull final Element aParentElement,
+                                                     @Nullable final String sNamespaceURI,
+                                                     @NonNull final String sLocalName)
+  {
+    final Element aChildElement = sNamespaceURI == null ? XMLHelper.getFirstChildElementOfName (aParentElement,
+                                                                                                sLocalName)
+                                                        : XMLHelper.getFirstChildElementOfName (aParentElement,
+                                                                                                sNamespaceURI,
+                                                                                                sLocalName);
+    return aChildElement == null ? null : StringHelper.trim (aChildElement.getTextContent ());
+  }
+
+  /**
+   * Check if the provided SOAP document represents a SOAP Fault and return the respective
+   * <code>Fault</code> element. The Fault must be the first element child of the SOAP
+   * <code>Body</code>. Both the SOAP 1.1 and the SOAP 1.2 namespace URI are accepted, no matter
+   * what SOAP version the conversation expects. The match is done on namespace URI and local name
+   * only - never on the namespace prefix.
+   *
+   * @param aSoapDocument
+   *        The parsed SOAP document to check. May be <code>null</code>.
+   * @return The <code>Fault</code> element or <code>null</code> if the document is not a SOAP
+   *         Fault.
+   */
+  @Nullable
+  public static Element getSoapFaultElementOrNull (@Nullable final Document aSoapDocument)
+  {
+    if (aSoapDocument == null)
+      return null;
+
+    final Element aRootElement = aSoapDocument.getDocumentElement ();
+    if (aRootElement == null)
+      return null;
+
+    // Accept SOAP 1.1 and SOAP 1.2, independent of the expected SOAP version
+    final ESoapVersion eSoapVersion = ESoapVersion.getFromNamespaceURIOrNull (aRootElement.getNamespaceURI ());
+    if (eSoapVersion == null)
+      return null;
+
+    final String sNamespaceURI = eSoapVersion.getNamespaceURI ();
+    final Element aBodyElement = XMLHelper.getFirstChildElementOfName (aRootElement,
+                                                                       sNamespaceURI,
+                                                                       eSoapVersion.getBodyElementName ());
+    if (aBodyElement == null)
+      return null;
+
+    final Element aBodyFirstChild = XMLHelper.getFirstChildElement (aBodyElement);
+    if (aBodyFirstChild == null)
+      return null;
+
+    // Check the local name first, for a fast rejection of the common non-fault case
+    if (!"Fault".equals (aBodyFirstChild.getLocalName ()))
+      return null;
+    if (!sNamespaceURI.equals (aBodyFirstChild.getNamespaceURI ()))
+      return null;
+
+    return aBodyFirstChild;
+  }
+
+  /**
+   * Check if the provided SOAP document represents a SOAP Fault and parse it into an
+   * {@link AS4SoapFault}. The raw XML for dumping is created by serializing the provided document.
+   *
+   * @param aSoapDocument
+   *        The parsed SOAP document to check. May be <code>null</code>.
+   * @return <code>null</code> if the document is not a SOAP Fault.
+   * @see #getSoapFaultElementOrNull(Document)
+   */
+  @Nullable
+  public static AS4SoapFault createOrNull (@Nullable final Document aSoapDocument)
+  {
+    return createOrNull (aSoapDocument, null);
+  }
+
+  /**
+   * Check if the provided SOAP document represents a SOAP Fault and parse it into an
+   * {@link AS4SoapFault}.
+   *
+   * @param aSoapDocument
+   *        The parsed SOAP document to check. May be <code>null</code>.
+   * @param sRawXML
+   *        The raw XML the document was parsed from, for dumping. If <code>null</code>, the
+   *        provided document is serialized instead.
+   * @return <code>null</code> if the document is not a SOAP Fault.
+   * @see #getSoapFaultElementOrNull(Document)
+   */
+  @Nullable
+  public static AS4SoapFault createOrNull (@Nullable final Document aSoapDocument, @Nullable final String sRawXML)
+  {
+    final Element aFaultElement = getSoapFaultElementOrNull (aSoapDocument);
+    if (aFaultElement == null)
+      return null;
+
+    // The detection above already verified it's one of the two known namespace URIs
+    final ESoapVersion eSoapVersion = ESoapVersion.getFromNamespaceURIOrNull (aFaultElement.getNamespaceURI ());
+    final String sRealRawXML = sRawXML != null ? sRawXML : XMLWriter.getNodeAsString (aSoapDocument);
+
+    return switch (eSoapVersion)
+    {
+      case SOAP_11 ->
+      {
+        // All fault child elements are unqualified
+        final Element aFaultCodeElement = XMLHelper.getFirstChildElementOfName (aFaultElement, "faultcode");
+        final QName aFaultCode = aFaultCodeElement == null ? null
+                                                           : _parseQName (aFaultCodeElement.getTextContent (),
+                                                                          aFaultCodeElement);
+        final String sFaultString = _getChildElementTextContent (aFaultElement, null, "faultstring");
+        final String sFaultActor = _getChildElementTextContent (aFaultElement, null, "faultactor");
+        final Element aDetailElement = XMLHelper.getFirstChildElementOfName (aFaultElement, "detail");
+        yield new AS4SoapFault (eSoapVersion, aFaultCode, null, sFaultString, sFaultActor, aDetailElement, sRealRawXML);
+      }
+      case SOAP_12 ->
+      {
+        // SOAP 1.2 - all fault child elements are in the SOAP 1.2 namespace
+        final String sNamespaceURI = eSoapVersion.getNamespaceURI ();
+        QName aFaultCode = null;
+        QName aFaultSubcode = null;
+        final Element aCodeElement = XMLHelper.getFirstChildElementOfName (aFaultElement, sNamespaceURI, "Code");
+        if (aCodeElement != null)
+        {
+          final Element aValueElement = XMLHelper.getFirstChildElementOfName (aCodeElement, sNamespaceURI, "Value");
+          if (aValueElement != null)
+            aFaultCode = _parseQName (aValueElement.getTextContent (), aValueElement);
+
+          final Element aSubcodeElement = XMLHelper.getFirstChildElementOfName (aCodeElement, sNamespaceURI, "Subcode");
+          if (aSubcodeElement != null)
+          {
+            final Element aSubcodeValueElement = XMLHelper.getFirstChildElementOfName (aSubcodeElement,
+                                                                                       sNamespaceURI,
+                                                                                       "Value");
+            if (aSubcodeValueElement != null)
+              aFaultSubcode = _parseQName (aSubcodeValueElement.getTextContent (), aSubcodeValueElement);
+          }
+        }
+
+        String sFaultReason = null;
+        final Element aReasonElement = XMLHelper.getFirstChildElementOfName (aFaultElement, sNamespaceURI, "Reason");
+        if (aReasonElement != null)
+        {
+          // Take the first "Text" element
+          final Element aTextElement = XMLHelper.getFirstChildElementOfName (aReasonElement, sNamespaceURI, "Text");
+          if (aTextElement != null)
+            sFaultReason = StringHelper.trim (aTextElement.getTextContent ());
+        }
+
+        final String sRole = _getChildElementTextContent (aFaultElement, sNamespaceURI, "Role");
+        final Element aDetailElement = XMLHelper.getFirstChildElementOfName (aFaultElement, sNamespaceURI, "Detail");
+        yield new AS4SoapFault (eSoapVersion,
+                                aFaultCode,
+                                aFaultSubcode,
+                                sFaultReason,
+                                sRole,
+                                aDetailElement,
+                                sRealRawXML);
+      }
+    };
+  }
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFaultException.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFaultException.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.helger.base.enforce.ValueEnforcer;
+import com.helger.base.string.StringHelper;
 
 /**
  * Exception that indicates that a SOAP Fault with a {@link EAS4FaultDisposition#PERMANENT}
@@ -64,6 +65,15 @@ public class AS4SoapFaultException extends IOException
   public String getSentMessageID ()
   {
     return m_sSentMessageID;
+  }
+
+  /**
+   * @return <code>true</code> if the AS4 Message ID of the sent message the fault was received for
+   *         is present, <code>false</code> otherwise.
+   */
+  public boolean hasSentMessageID ()
+  {
+    return StringHelper.isNotEmpty (m_sSentMessageID);
   }
 
   /**

--- a/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFaultException.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFaultException.java
@@ -28,6 +28,20 @@ import com.helger.base.string.StringHelper;
  * Exception that indicates that a SOAP Fault with a {@link EAS4FaultDisposition#PERMANENT}
  * disposition was received as the synchronous response. It is derived from {@link IOException} so
  * that it passes through the HTTP retry handling, where it explicitly stops all further retries.
+ * <br>
+ * Note: this exception deliberately does NOT extend
+ * {@link com.helger.phase4.util.Phase4Exception}, even though that would be the more natural base
+ * class. It is thrown from within an Apache HttpClient
+ * {@link org.apache.hc.core5.http.io.HttpClientResponseHandler}, whose <code>handleResponse</code>
+ * method is declared to only throw <code>HttpException</code> and {@link IOException} - a checked
+ * <code>Phase4Exception</code> could not be thrown from there at all. Additionally it must pass
+ * through <code>BasicHttpPoster.sendGenericMessageWithRetries</code> and
+ * <code>AbstractAS4Client.sendMessageWithRetries</code>, which are both declared to only throw
+ * {@link IOException} - extending their <code>throws</code> clauses would be a source-incompatible
+ * change for all direct callers. Making this exception a <code>Phase4Exception</code> would
+ * therefore require an additional internal {@link IOException} based carrier exception for the
+ * HTTP layer, at the price of direct callers of the low-level sending methods no longer seeing
+ * this exception type.
  *
  * @author Philip Helger
  * @since 4.6.0

--- a/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFaultException.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/AS4SoapFaultException.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model.soapfault;
+
+import java.io.IOException;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.base.enforce.ValueEnforcer;
+
+/**
+ * Exception that indicates that a SOAP Fault with a {@link EAS4FaultDisposition#PERMANENT}
+ * disposition was received as the synchronous response. It is derived from {@link IOException} so
+ * that it passes through the HTTP retry handling, where it explicitly stops all further retries.
+ *
+ * @author Philip Helger
+ * @since 4.6.0
+ */
+public class AS4SoapFaultException extends IOException
+{
+  private final transient AS4SoapFault m_aSoapFault;
+  private String m_sSentMessageID;
+
+  public AS4SoapFaultException (@NonNull final AS4SoapFault aSoapFault)
+  {
+    super ("Received a SOAP " +
+           aSoapFault.getSoapVersion ().getVersion () +
+           " Fault with code " +
+           (aSoapFault.hasFaultCode () ? "'" + aSoapFault.getFaultCode () + "'" : "<none>") +
+           " and reason " +
+           (aSoapFault.getFaultReason () != null ? "'" + aSoapFault.getFaultReason () + "'" : "<none>"));
+    m_aSoapFault = aSoapFault;
+  }
+
+  /**
+   * @return The SOAP Fault that was received. Never <code>null</code>.
+   */
+  @NonNull
+  public AS4SoapFault getSoapFault ()
+  {
+    return m_aSoapFault;
+  }
+
+  /**
+   * @return The AS4 Message ID of the sent message the fault was received for. May be
+   *         <code>null</code> if it was not determined.
+   */
+  @Nullable
+  public String getSentMessageID ()
+  {
+    return m_sSentMessageID;
+  }
+
+  /**
+   * Set the AS4 Message ID of the sent message the fault was received for.
+   *
+   * @param sSentMessageID
+   *        The AS4 Message ID. May not be <code>null</code>.
+   * @return this for chaining
+   */
+  @NonNull
+  public AS4SoapFaultException setSentMessageID (@NonNull final String sSentMessageID)
+  {
+    ValueEnforcer.notNull (sSentMessageID, "SentMessageID");
+    m_sSentMessageID = sSentMessageID;
+    return this;
+  }
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/EAS4FaultDisposition.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/model/soapfault/EAS4FaultDisposition.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model.soapfault;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.id.IHasID;
+import com.helger.base.lang.EnumHelper;
+
+/**
+ * Defines the retry disposition of a received SOAP Fault.
+ *
+ * @author Philip Helger
+ * @since 4.6.0
+ */
+public enum EAS4FaultDisposition implements IHasID <String>
+{
+  /**
+   * The fault indicates a definitive rejection by the receiving side. Retrying the same message
+   * will not succeed.
+   */
+  PERMANENT ("permanent"),
+  /**
+   * The fault indicates a temporary problem on the receiving side. Retrying the same message may
+   * succeed.
+   */
+  TRANSIENT ("transient");
+
+  private final String m_sID;
+
+  EAS4FaultDisposition (@NonNull @Nonempty final String sID)
+  {
+    m_sID = sID;
+  }
+
+  @NonNull
+  @Nonempty
+  public String getID ()
+  {
+    return m_sID;
+  }
+
+  public boolean isPermanent ()
+  {
+    return this == PERMANENT;
+  }
+
+  public boolean isTransient ()
+  {
+    return this == TRANSIENT;
+  }
+
+  @Nullable
+  public static EAS4FaultDisposition getFromIDOrNull (@Nullable final String sID)
+  {
+    return EnumHelper.getFromIDOrNull (EAS4FaultDisposition.class, sID);
+  }
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/sender/AS4BidirectionalClientHelper.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/sender/AS4BidirectionalClientHelper.java
@@ -17,8 +17,11 @@
 package com.helger.phase4.sender;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -26,9 +29,16 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
+import org.w3c.dom.Document;
 
+import com.helger.base.array.ArrayHelper;
+import com.helger.base.io.stream.StreamHelper;
+import com.helger.base.string.StringHelper;
 import com.helger.base.wrapper.Wrapper;
 import com.helger.http.CHttp;
+import com.helger.http.CHttpHeader;
+import com.helger.http.header.HttpHeaderMap;
+import com.helger.httpclient.response.ExtendedHttpResponseException;
 import com.helger.phase4.attachment.IAS4IncomingAttachmentFactory;
 import com.helger.phase4.attachment.WSS4JAttachment;
 import com.helger.phase4.client.AS4ClientPullRequestMessage;
@@ -37,9 +47,11 @@ import com.helger.phase4.client.AS4ClientUserMessage;
 import com.helger.phase4.client.IAS4ClientBuildMessageCallback;
 import com.helger.phase4.client.IAS4RetryCallback;
 import com.helger.phase4.crypto.IAS4CryptoFactory;
+import com.helger.phase4.dump.AS4DumpManager;
 import com.helger.phase4.dump.IAS4IncomingDumper;
 import com.helger.phase4.dump.IAS4OutgoingDumper;
 import com.helger.phase4.ebms3header.Ebms3Property;
+import com.helger.phase4.ebms3header.Ebms3SignalMessage;
 import com.helger.phase4.incoming.AS4IncomingHandler;
 import com.helger.phase4.incoming.AS4IncomingMessageMetadata;
 import com.helger.phase4.incoming.IAS4IncomingProfileSelector;
@@ -50,9 +62,15 @@ import com.helger.phase4.incoming.crypto.IAS4IncomingSecurityConfiguration;
 import com.helger.phase4.logging.Phase4LoggerFactory;
 import com.helger.phase4.messaging.http.GenericAS4HttpResponseHandler;
 import com.helger.phase4.messaging.http.GenericAS4HttpResponseHandler.HttpResponseData;
+import com.helger.phase4.model.EAS4ResponseType;
 import com.helger.phase4.model.pmode.IPMode;
 import com.helger.phase4.model.pmode.resolve.IAS4PModeResolver;
+import com.helger.phase4.model.soapfault.AS4SoapFault;
+import com.helger.phase4.model.soapfault.AS4SoapFaultException;
 import com.helger.phase4.util.Phase4Exception;
+import com.helger.xml.sax.DoNothingSAXErrorHandler;
+import com.helger.xml.serialize.read.DOMReader;
+import com.helger.xml.serialize.read.DOMReaderSettings;
 
 import jakarta.mail.MessagingException;
 
@@ -68,6 +86,89 @@ public final class AS4BidirectionalClientHelper
   private AS4BidirectionalClientHelper ()
   {}
 
+  /**
+   * Try to interpret the provided response payload as a SOAP Fault. Any XML parsing errors are
+   * collected silently, because non-XML response payloads are a valid case here.
+   *
+   * @param aResponsePayload
+   *        The response payload to check. May be <code>null</code>.
+   * @param sRawXML
+   *        The raw XML string for dumping. May be <code>null</code> in which case the parsed
+   *        document is serialized on demand.
+   * @return <code>null</code> if the response payload is not a SOAP Fault.
+   */
+  @Nullable
+  private static AS4SoapFault _findSoapFault (final byte @Nullable [] aResponsePayload, @Nullable final String sRawXML)
+  {
+    if (ArrayHelper.isEmpty (aResponsePayload))
+      return null;
+
+    final Document aSoapDocument = DOMReader.readXMLDOM (aResponsePayload,
+                                                         new DOMReaderSettings ().setErrorHandler (new DoNothingSAXErrorHandler ()));
+    return AS4SoapFault.createOrNull (aSoapDocument, sRawXML);
+  }
+
+  /**
+   * Handle a received SOAP Fault: route the raw fault XML through the incoming dumper and invoke
+   * the SOAP Fault consumer, defaulting to error logging.
+   */
+  private static void _handleReceivedSoapFault (@NonNull final AS4SoapFault aSoapFault,
+                                                @Nullable final String sSentMessageID,
+                                                @Nullable final AS4ClientSentMessage <byte []> aClientSentMessage,
+                                                @Nullable final AS4IncomingMessageMetadata aResponseMessageMetadata,
+                                                @Nullable final HttpResponse aHttpResponse,
+                                                @Nullable final IAS4IncomingDumper aIncomingDumper,
+                                                @Nullable final IAS4SoapFaultConsumer aSoapFaultConsumer) throws Phase4Exception
+  {
+    // Fallback to global dumper if none is provided
+    final IAS4IncomingDumper aRealIncomingDumper = aIncomingDumper != null ? aIncomingDumper
+                                                                           : AS4DumpManager.getIncomingDumper ();
+    if (aRealIncomingDumper != null)
+    {
+      if (aResponseMessageMetadata != null)
+      {
+        // Create header map from response headers
+        final HttpHeaderMap aHttpHeaders = new HttpHeaderMap ();
+        if (aHttpResponse != null)
+          for (final Header aHeader : aHttpResponse.getHeaders ())
+            aHttpHeaders.addHeader (aHeader.getName (), aHeader.getValue ());
+
+        try
+        {
+          final OutputStream aDumpOS = aRealIncomingDumper.onNewRequest (aResponseMessageMetadata, aHttpHeaders);
+          if (aDumpOS != null)
+          {
+            try
+            {
+              // Prefer the received bytes over the serialized fault
+              if (aClientSentMessage != null && aClientSentMessage.hasResponseContent ())
+                aDumpOS.write (aClientSentMessage.getResponseContent ());
+              else
+                aDumpOS.write (aSoapFault.getRawXML ().getBytes (StandardCharsets.UTF_8));
+            }
+            finally
+            {
+              StreamHelper.close (aDumpOS);
+            }
+            aRealIncomingDumper.onEndRequest (aResponseMessageMetadata, null);
+          }
+        }
+        catch (final IOException ex)
+        {
+          LOGGER.error ("Failed to dump the received SOAP Fault", ex);
+        }
+      }
+      else
+        LOGGER.warn ("Cannot dump the received SOAP Fault, because no message metadata is available");
+    }
+
+    // Invoke the callback, defaulting to error logging
+    final IAS4SoapFaultConsumer aRealSoapFaultConsumer = aSoapFaultConsumer != null ? aSoapFaultConsumer
+                                                                                    : new LoggingAS4SoapFaultConsumer ();
+    aRealSoapFaultConsumer.handleSoapFault (sSentMessageID, aSoapFault, aClientSentMessage);
+  }
+
+  @Deprecated (forRemoval = true, since = "4.6.0")
   public static void sendAS4UserMessageAndReceiveAS4SignalMessage (@NonNull final IAS4CryptoFactory aCryptoFactorySign,
                                                                    @NonNull final IAS4CryptoFactory aCryptoFactoryCrypt,
                                                                    @NonNull final IAS4PModeResolver aPModeResolver,
@@ -88,6 +189,56 @@ public final class AS4BidirectionalClientHelper
                                                                                                                                                                Phase4Exception,
                                                                                                                                                                WSSecurityException,
                                                                                                                                                                MessagingException
+  {
+    sendAS4UserMessageAndReceiveAS4SignalMessage (aCryptoFactorySign,
+                                                  aCryptoFactoryCrypt,
+                                                  aPModeResolver,
+                                                  aIAF,
+                                                  aIncomingProfileSelector,
+                                                  aClientUserMsg,
+                                                  aLocale,
+                                                  sURL,
+                                                  aBuildMessageCallback,
+                                                  aOutgoingDumper,
+                                                  aIncomingDumper,
+                                                  aIncomingSecurityConfiguration,
+                                                  aIncomingReceiverConfiguration,
+                                                  aRetryCallback,
+                                                  aRawResponseConsumer,
+                                                  aSignalMsgConsumer,
+                                                  aSignalMsgValidationResultHandler,
+                                                  null);
+  }
+
+  /**
+   * Same as the other overload, but with an additional SOAP Fault consumer that is invoked if the
+   * synchronous response is a plain SOAP Fault instead of an ebMS Signal Message. If a received
+   * SOAP Fault has a permanent disposition, all HTTP level retries are stopped and an
+   * {@link AS4SoapFaultException} is thrown.
+   *
+   * @since 4.6.0
+   */
+  public static void sendAS4UserMessageAndReceiveAS4SignalMessage (@NonNull final IAS4CryptoFactory aCryptoFactorySign,
+                                                                   @NonNull final IAS4CryptoFactory aCryptoFactoryCrypt,
+                                                                   @NonNull final IAS4PModeResolver aPModeResolver,
+                                                                   @NonNull final IAS4IncomingAttachmentFactory aIAF,
+                                                                   @NonNull final IAS4IncomingProfileSelector aIncomingProfileSelector,
+                                                                   @NonNull final AS4ClientUserMessage aClientUserMsg,
+                                                                   @NonNull final Locale aLocale,
+                                                                   @NonNull final String sURL,
+                                                                   @Nullable final IAS4ClientBuildMessageCallback aBuildMessageCallback,
+                                                                   @Nullable final IAS4OutgoingDumper aOutgoingDumper,
+                                                                   @Nullable final IAS4IncomingDumper aIncomingDumper,
+                                                                   @NonNull final IAS4IncomingSecurityConfiguration aIncomingSecurityConfiguration,
+                                                                   @NonNull final IAS4IncomingReceiverConfiguration aIncomingReceiverConfiguration,
+                                                                   @Nullable final IAS4RetryCallback aRetryCallback,
+                                                                   @Nullable final IAS4RawResponseConsumer aRawResponseConsumer,
+                                                                   @Nullable final IAS4SignalMessageConsumer aSignalMsgConsumer,
+                                                                   @Nullable final IAS4SignalMessageValidationResultHandler aSignalMsgValidationResultHandler,
+                                                                   @Nullable final IAS4SoapFaultConsumer aSoapFaultConsumer) throws IOException,
+                                                                                                                             Phase4Exception,
+                                                                                                                             WSSecurityException,
+                                                                                                                             MessagingException
   {
     LOGGER.info ("Sending AS4 UserMessage to '" +
                  sURL +
@@ -121,24 +272,106 @@ public final class AS4BidirectionalClientHelper
       }
     }
 
+    // Define the HTTP response handler
     final Wrapper <HttpResponse> aWrappedHttpResponse = new Wrapper <> ();
+    final Wrapper <AS4SoapFault> aSoapFaultKeeper = new Wrapper <> ();
     final HttpClientResponseHandler <byte []> aHttpResponseHdl = aHttpResponse -> {
-      // Accepts all response codes
-      final HttpResponseData aResponseData = GenericAS4HttpResponseHandler.INSTANCE.handleResponse (aHttpResponse);
-
       // Remember source response object
       aWrappedHttpResponse.set (aHttpResponse);
 
-      // Read response payload
-      return EntityUtils.toByteArray (aResponseData.entity ());
+      // A SOAP Fault can never be contained in a multipart response
+      final Header aContentTypeHeader = aHttpResponse.getFirstHeader (CHttpHeader.CONTENT_TYPE);
+      final boolean bMayBeSoapFault = aContentTypeHeader == null ||
+        !StringHelper.startsWithIgnoreCase (aContentTypeHeader.getValue (), "multipart");
+
+      final byte [] aResponsePayload;
+      try
+      {
+        // Accepts all response codes, if enabled in the configuration
+        final HttpResponseData aResponseData = GenericAS4HttpResponseHandler.INSTANCE.handleResponse (aHttpResponse);
+
+        // Read response payload
+        aResponsePayload = EntityUtils.toByteArray (aResponseData.entity ());
+      }
+      catch (final ExtendedHttpResponseException ex)
+      {
+        // Only thrown for non-success status codes, if "accept all status codes" is disabled.
+        // Check if the response body contains a SOAP Fault, to eventually stop pointless retries
+        if (bMayBeSoapFault)
+        {
+          final AS4SoapFault aSoapFault = _findSoapFault (ex.directGetResponseBody (), ex.getResponseBodyAsString ());
+          if (aSoapFault != null)
+          {
+            aSoapFaultKeeper.set (aSoapFault);
+
+            // Only throw exception for permanent errors
+            if (aSoapFault.getDisposition ().isPermanent ())
+              throw new AS4SoapFaultException (aSoapFault);
+          }
+        }
+        throw ex;
+      }
+
+      // Check for a SOAP Fault independent of the HTTP status code, because non-conforming peers
+      // may return a fault with HTTP 200
+      if (bMayBeSoapFault)
+      {
+        final AS4SoapFault aSoapFault = _findSoapFault (aResponsePayload, null);
+        if (aSoapFault != null)
+          aSoapFaultKeeper.set (aSoapFault);
+      }
+      return aResponsePayload;
     };
 
-    // Main HTTP sending
-    final AS4ClientSentMessage <byte []> aClientSentMessage = aClientUserMsg.sendMessageWithRetries (sURL,
-                                                                                                     aHttpResponseHdl,
-                                                                                                     aBuildMessageCallback,
-                                                                                                     aOutgoingDumper,
-                                                                                                     aRetryCallback);
+    final AS4ClientSentMessage <byte []> aClientSentMessage;
+    try
+    {
+      // Main HTTP sending
+      aClientSentMessage = aClientUserMsg.sendMessageWithRetries (sURL,
+                                                                  aHttpResponseHdl,
+                                                                  aBuildMessageCallback,
+                                                                  aOutgoingDumper,
+                                                                  aRetryCallback);
+    }
+    catch (final AS4SoapFaultException ex)
+    {
+      // A SOAP Fault with a permanent disposition stopped all retries
+      LOGGER.info ("The synchronous AS4 response was classified as " + EAS4ResponseType.SOAP_FAULT);
+      AS4IncomingMessageMetadata aResponseMessageMetadata = null;
+      if (ex.hasSentMessageID ())
+      {
+        aResponseMessageMetadata = AS4IncomingMessageMetadata.createForResponse (ex.getSentMessageID ())
+                                                             .setRemoteAddr (sURL);
+        if (aWrappedHttpResponse.isSet ())
+          aResponseMessageMetadata.setResponseHttpStatusCode (aWrappedHttpResponse.get ().getCode ());
+      }
+      _handleReceivedSoapFault (ex.getSoapFault (),
+                                ex.getSentMessageID (),
+                                null,
+                                aResponseMessageMetadata,
+                                aWrappedHttpResponse.get (),
+                                aIncomingDumper,
+                                aSoapFaultConsumer);
+      throw ex;
+    }
+    catch (final IOException ex)
+    {
+      // If a SOAP Fault with a transient disposition was detected on the way (only possible if
+      // "accept all status codes" is disabled), surface it nevertheless
+      final AS4SoapFault aSoapFault = aSoapFaultKeeper.get ();
+      if (aSoapFault != null)
+      {
+        LOGGER.info ("The synchronous AS4 response was classified as " + EAS4ResponseType.SOAP_FAULT);
+        _handleReceivedSoapFault (aSoapFault,
+                                  null,
+                                  null,
+                                  null,
+                                  aWrappedHttpResponse.get (),
+                                  aIncomingDumper,
+                                  aSoapFaultConsumer);
+      }
+      throw ex;
+    }
     final String sRequestAS4MessageID = aClientSentMessage.getMessageID ();
     LOGGER.info ("Successfully transmitted AS4 UserMessage with message ID '" +
                  sRequestAS4MessageID +
@@ -150,6 +383,7 @@ public final class AS4BidirectionalClientHelper
       aRawResponseConsumer.handleResponse (aClientSentMessage);
 
     // Try interpret result as SignalMessage
+    final EAS4ResponseType eResponseType;
     if (aClientSentMessage.hasResponseContent () && aClientSentMessage.getResponseContent ().length > 0)
     {
       final AS4IncomingMessageMetadata aResponseMessageMetadata = AS4IncomingMessageMetadata.createForResponse (sRequestAS4MessageID)
@@ -164,31 +398,61 @@ public final class AS4BidirectionalClientHelper
           LOGGER.warn ("HTTP response uses non-success status code " + nResponseHttpStatusCode);
       }
 
-      // Validate the DSSig references between sent and received msg
-      final IAS4SignalMessageConsumer aRealSignalMsgConsumer = new ValidatingAS4SignalMsgConsumer (aClientSentMessage,
-                                                                                                   aSignalMsgConsumer,
-                                                                                                   aSignalMsgValidationResultHandler);
+      final AS4SoapFault aSoapFault = aSoapFaultKeeper.get ();
+      if (aSoapFault != null)
+      {
+        // A SOAP Fault was received - it cannot be interpreted as an ebMS Signal Message
+        eResponseType = EAS4ResponseType.SOAP_FAULT;
+        _handleReceivedSoapFault (aSoapFault,
+                                  sRequestAS4MessageID,
+                                  aClientSentMessage,
+                                  aResponseMessageMetadata,
+                                  aWrappedHttpResponse.get (),
+                                  aIncomingDumper,
+                                  aSoapFaultConsumer);
+      }
+      else
+      {
+        // Validate the DSSig references between sent and received msg
+        final IAS4SignalMessageConsumer aRealSignalMsgConsumer = new ValidatingAS4SignalMsgConsumer (aClientSentMessage,
+                                                                                                     aSignalMsgConsumer,
+                                                                                                     aSignalMsgValidationResultHandler);
 
-      // Read response as EBMS3 Signal Message
-      // Read it in any case to ensure signature validation etc. happens
-      AS4IncomingHandler.parseSignalMessage (aCryptoFactorySign,
-                                             aCryptoFactoryCrypt,
-                                             aPModeResolver,
-                                             aIAF,
-                                             aIncomingProfileSelector,
-                                             aClientUserMsg.getAS4ResourceHelper (),
-                                             aClientUserMsg.getPMode (),
-                                             aLocale,
-                                             aResponseMessageMetadata,
-                                             aWrappedHttpResponse.get (),
-                                             aClientSentMessage.getResponseContent (),
-                                             aIncomingDumper,
-                                             aIncomingSecurityConfiguration,
-                                             aIncomingReceiverConfiguration,
-                                             aRealSignalMsgConsumer);
+        // Read response as EBMS3 Signal Message
+        // Read it in any case to ensure signature validation etc. happens
+        final Ebms3SignalMessage aSignalMsg = AS4IncomingHandler.parseSignalMessage (aCryptoFactorySign,
+                                                                                     aCryptoFactoryCrypt,
+                                                                                     aPModeResolver,
+                                                                                     aIAF,
+                                                                                     aIncomingProfileSelector,
+                                                                                     aClientUserMsg.getAS4ResourceHelper (),
+                                                                                     aClientUserMsg.getPMode (),
+                                                                                     aLocale,
+                                                                                     aResponseMessageMetadata,
+                                                                                     aWrappedHttpResponse.get (),
+                                                                                     aClientSentMessage.getResponseContent (),
+                                                                                     aIncomingDumper,
+                                                                                     aIncomingSecurityConfiguration,
+                                                                                     aIncomingReceiverConfiguration,
+                                                                                     aRealSignalMsgConsumer);
+        if (aSignalMsg == null)
+          eResponseType = EAS4ResponseType.UNPARSABLE;
+        else
+          if (aSignalMsg.hasErrorEntries ())
+            eResponseType = EAS4ResponseType.EBMS_ERROR;
+          else
+            if (aSignalMsg.getReceipt () != null)
+              eResponseType = EAS4ResponseType.RECEIPT;
+            else
+              eResponseType = EAS4ResponseType.UNPARSABLE;
+      }
     }
     else
+    {
       LOGGER.info ("AS4 ResponseEntity is empty");
+      eResponseType = EAS4ResponseType.EMPTY;
+    }
+    LOGGER.info ("The synchronous AS4 response was classified as " + eResponseType);
   }
 
   public static void sendAS4PullRequestAndReceiveAS4UserMessage (@NonNull final IAS4CryptoFactory aCryptoFactorySign,

--- a/phase4-lib/src/main/java/com/helger/phase4/sender/AbstractAS4UserMessageBuilder.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/sender/AbstractAS4UserMessageBuilder.java
@@ -41,6 +41,7 @@ import com.helger.phase4.logging.Phase4LoggerFactory;
 import com.helger.phase4.model.MessageProperty;
 import com.helger.phase4.model.message.MessageHelperMethods;
 import com.helger.phase4.model.pmode.IPMode;
+import com.helger.phase4.model.soapfault.AS4SoapFault;
 import com.helger.phase4.util.AS4ResourceHelper;
 import com.helger.phase4.util.Phase4Exception;
 
@@ -86,6 +87,7 @@ public abstract class AbstractAS4UserMessageBuilder <IMPLTYPE extends AbstractAS
 
   protected IAS4SignalMessageConsumer m_aSignalMsgConsumer;
   protected IAS4SignalMessageValidationResultHandler m_aSignalMsgValidationResultHdl;
+  protected IAS4SoapFaultConsumer m_aSoapFaultConsumer;
 
   /**
    * Create a new builder
@@ -758,6 +760,33 @@ public abstract class AbstractAS4UserMessageBuilder <IMPLTYPE extends AbstractAS
     return thisAsT ();
   }
 
+  /**
+   * @return The optional SOAP Fault consumer. May be <code>null</code>.
+   * @since 4.6.0
+   */
+  @Nullable
+  public final IAS4SoapFaultConsumer soapFaultConsumer ()
+  {
+    return m_aSoapFaultConsumer;
+  }
+
+  /**
+   * Set an optional SOAP Fault consumer that is invoked, if the synchronous response is a plain
+   * SOAP Fault instead of an ebMS Signal Message. If no consumer is set, a received SOAP Fault is
+   * logged on error level. This method is optional and must not be called prior to sending.
+   *
+   * @param aSoapFaultConsumer
+   *        The optional SOAP Fault consumer. May be <code>null</code>.
+   * @return this for chaining
+   * @since 4.6.0
+   */
+  @NonNull
+  public final IMPLTYPE soapFaultConsumer (@Nullable final IAS4SoapFaultConsumer aSoapFaultConsumer)
+  {
+    m_aSoapFaultConsumer = aSoapFaultConsumer;
+    return thisAsT ();
+  }
+
   @Override
   @NonNull
   @OverridingMethodsMustInvokeSuper
@@ -946,6 +975,7 @@ public abstract class AbstractAS4UserMessageBuilder <IMPLTYPE extends AbstractAS
   public final EAS4UserMessageSendResult sendMessageAndCheckForReceipt (@Nullable final Consumer <? super Phase4Exception> aExceptionConsumer)
   {
     final IAS4SignalMessageConsumer aOriginalSignalMsgConsumer = m_aSignalMsgConsumer;
+    final IAS4SoapFaultConsumer aOriginalSoapFaultConsumer = m_aSoapFaultConsumer;
     // Store the received data
     final Wrapper <Ebms3SignalMessage> aSignalMsgKeeper = new Wrapper <> ();
     final IAS4SignalMessageConsumer aInternalSignalMsgConsumer = (aSignalMsg,
@@ -953,6 +983,7 @@ public abstract class AbstractAS4UserMessageBuilder <IMPLTYPE extends AbstractAS
                                                                   aIncomingState) -> {
       aSignalMsgKeeper.set (aSignalMsg);
     };
+    final Wrapper <AS4SoapFault> aSoapFaultKeeper = new Wrapper <> ();
 
     try
     {
@@ -973,11 +1004,36 @@ public abstract class AbstractAS4UserMessageBuilder <IMPLTYPE extends AbstractAS
         };
       }
 
+      // this is not thread-safe because m_aSoapFaultConsumer is modified
+      if (aOriginalSoapFaultConsumer == null)
+      {
+        // Store the fault and keep the default error logging
+        final IAS4SoapFaultConsumer aLoggingSoapFaultConsumer = new LoggingAS4SoapFaultConsumer ();
+        m_aSoapFaultConsumer = (sSentMessageID, aSoapFault, aClientSentMessage) -> {
+          aSoapFaultKeeper.set (aSoapFault);
+          aLoggingSoapFaultConsumer.handleSoapFault (sSentMessageID, aSoapFault, aClientSentMessage);
+        };
+      }
+      else
+      {
+        // Store the fault and call the original handler
+        m_aSoapFaultConsumer = (sSentMessageID, aSoapFault, aClientSentMessage) -> {
+          aSoapFaultKeeper.set (aSoapFault);
+          aOriginalSoapFaultConsumer.handleSoapFault (sSentMessageID, aSoapFault, aClientSentMessage);
+        };
+      }
+
       // Main sending
       if (sendMessage ().isFailure ())
       {
         // Parameters are missing/incorrect
         return EAS4UserMessageSendResult.INVALID_PARAMETERS;
+      }
+
+      if (aSoapFaultKeeper.isSet ())
+      {
+        // A SOAP Fault was returned instead of an AS4 Signal Message
+        return EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED;
       }
 
       final Ebms3SignalMessage aSignalMsg = aSignalMsgKeeper.get ();
@@ -1020,14 +1076,21 @@ public abstract class AbstractAS4UserMessageBuilder <IMPLTYPE extends AbstractAS
       if (aExceptionConsumer != null)
         aExceptionConsumer.accept (ex);
 
+      if (aSoapFaultKeeper.isSet ())
+      {
+        // A SOAP Fault with a permanent disposition was received and stopped the sending
+        return EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED;
+      }
+
       // Something went wrong - see the logs
       return ex.isRetryFeasible () ? EAS4UserMessageSendResult.TRANSPORT_ERROR
                                    : EAS4UserMessageSendResult.TRANSPORT_ERROR_NO_RETRY;
     }
     finally
     {
-      // Restore the original value
+      // Restore the original values
       m_aSignalMsgConsumer = aOriginalSignalMsgConsumer;
+      m_aSoapFaultConsumer = aOriginalSoapFaultConsumer;
     }
   }
 }

--- a/phase4-lib/src/main/java/com/helger/phase4/sender/AbstractAS4UserMessageBuilderMIMEPayload.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/sender/AbstractAS4UserMessageBuilderMIMEPayload.java
@@ -38,6 +38,7 @@ import com.helger.phase4.incoming.IAS4IncomingReceiverConfiguration;
 import com.helger.phase4.incoming.crypto.AS4IncomingSecurityConfiguration;
 import com.helger.phase4.incoming.crypto.IAS4IncomingSecurityConfiguration;
 import com.helger.phase4.logging.Phase4LoggerFactory;
+import com.helger.phase4.model.soapfault.AS4SoapFaultException;
 import com.helger.phase4.util.AS4ResourceHelper;
 import com.helger.phase4.util.Phase4Exception;
 
@@ -266,12 +267,18 @@ public abstract class AbstractAS4UserMessageBuilderMIMEPayload <IMPLTYPE extends
                                                                                  m_aRetryCallback,
                                                                                  m_aResponseConsumer,
                                                                                  m_aSignalMsgConsumer,
-                                                                                 m_aSignalMsgValidationResultHdl);
+                                                                                 m_aSignalMsgValidationResultHdl,
+                                                                                 m_aSoapFaultConsumer);
     }
     catch (final Phase4Exception ex)
     {
       // Re-throw
       throw ex;
+    }
+    catch (final AS4SoapFaultException ex)
+    {
+      // A SOAP Fault with a permanent disposition was received - a retry is not feasible
+      throw new Phase4Exception ("A permanent SOAP Fault was received", ex).setRetryFeasible (false);
     }
     catch (final Exception ex)
     {

--- a/phase4-lib/src/main/java/com/helger/phase4/sender/EAS4UserMessageSendResult.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/sender/EAS4UserMessageSendResult.java
@@ -56,6 +56,14 @@ public enum EAS4UserMessageSendResult implements IHasID <String>, ISuccessIndica
    */
   AS4_ERROR_MESSAGE_RECEIVED ("as4-error-msg-received"),
   /**
+   * A plain SOAP Fault was received instead of an AS4 Signal Message. Whether a retry is feasible
+   * depends on the disposition of the received fault - use a
+   * {@link AbstractAS4UserMessageBuilder#soapFaultConsumer(IAS4SoapFaultConsumer)} to access it.
+   *
+   * @since 4.6.0
+   */
+  SOAP_FAULT_RECEIVED ("soap-fault-received"),
+  /**
    * An AS4 Signal Message was received, but it was neither a Receipt nor an Error Message but
    * something else.
    */

--- a/phase4-lib/src/main/java/com/helger/phase4/sender/IAS4SoapFaultConsumer.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/sender/IAS4SoapFaultConsumer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.sender;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.phase4.client.AS4ClientSentMessage;
+import com.helger.phase4.model.soapfault.AS4SoapFault;
+import com.helger.phase4.util.Phase4Exception;
+
+/**
+ * Callback interface for handling a SOAP Fault that was received as the synchronous response to an
+ * outgoing AS4 message.
+ *
+ * @author Philip Helger
+ * @since 4.6.0
+ */
+@FunctionalInterface
+public interface IAS4SoapFaultConsumer
+{
+  /**
+   * Handle a received SOAP Fault.
+   *
+   * @param sSentMessageID
+   *        The AS4 Message ID of the sent message the fault was received for. May be
+   *        <code>null</code> if it could not be determined.
+   * @param aSoapFault
+   *        The received SOAP Fault. Never <code>null</code>.
+   * @param aClientSentMessage
+   *        The client sent message context. May be <code>null</code> if the fault interrupted the
+   *        sending process before the context was created.
+   * @throws Phase4Exception
+   *         in case of error
+   */
+  void handleSoapFault (@Nullable String sSentMessageID,
+                        @NonNull AS4SoapFault aSoapFault,
+                        @Nullable AS4ClientSentMessage <byte []> aClientSentMessage) throws Phase4Exception;
+}

--- a/phase4-lib/src/main/java/com/helger/phase4/sender/LoggingAS4SoapFaultConsumer.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/sender/LoggingAS4SoapFaultConsumer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.sender;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+
+import com.helger.phase4.client.AS4ClientSentMessage;
+import com.helger.phase4.logging.Phase4LoggerFactory;
+import com.helger.phase4.model.soapfault.AS4SoapFault;
+
+/**
+ * Default implementation of {@link IAS4SoapFaultConsumer} that logs the received SOAP Fault on
+ * error level.
+ *
+ * @author Philip Helger
+ * @since 4.6.0
+ */
+public class LoggingAS4SoapFaultConsumer implements IAS4SoapFaultConsumer
+{
+  private static final Logger LOGGER = Phase4LoggerFactory.getLogger (LoggingAS4SoapFaultConsumer.class);
+
+  public void handleSoapFault (@Nullable final String sSentMessageID,
+                               @NonNull final AS4SoapFault aSoapFault,
+                               @Nullable final AS4ClientSentMessage <byte []> aClientSentMessage)
+  {
+    LOGGER.error ("Received a SOAP " +
+                  aSoapFault.getSoapVersion ().getVersion () +
+                  " Fault as the response to AS4 message '" +
+                  sSentMessageID +
+                  "' with code " +
+                  (aSoapFault.hasFaultCode () ? "'" + aSoapFault.getFaultCode () + "'" : "<none>") +
+                  " and reason " +
+                  (aSoapFault.getFaultReason () != null ? "'" + aSoapFault.getFaultReason () + "'" : "<none>") +
+                  " (disposition " +
+                  aSoapFault.getDisposition () +
+                  ")");
+  }
+}

--- a/phase4-lib/src/test/java/com/helger/phase4/model/EAS4ResponseTypeTest.java
+++ b/phase4-lib/src/test/java/com/helger/phase4/model/EAS4ResponseTypeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.helger.base.string.StringHelper;
+
+/**
+ * Test class for class {@link EAS4ResponseType}.
+ *
+ * @author Philip Helger
+ */
+public final class EAS4ResponseTypeTest
+{
+  @Test
+  public void testBasic ()
+  {
+    for (final EAS4ResponseType e : EAS4ResponseType.values ())
+    {
+      assertTrue (StringHelper.isNotEmpty (e.getID ()));
+      assertSame (e, EAS4ResponseType.getFromIDOrNull (e.getID ()));
+    }
+    assertNull (EAS4ResponseType.getFromIDOrNull ("bla"));
+    assertNull (EAS4ResponseType.getFromIDOrNull (null));
+  }
+}

--- a/phase4-lib/src/test/java/com/helger/phase4/model/soapfault/AS4SoapFaultTest.java
+++ b/phase4-lib/src/test/java/com/helger/phase4/model/soapfault/AS4SoapFaultTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model.soapfault;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import com.helger.phase4.model.ESoapVersion;
+import com.helger.xml.serialize.read.DOMReader;
+
+/**
+ * Test class for class {@link AS4SoapFault}.
+ *
+ * @author Philip Helger
+ */
+public final class AS4SoapFaultTest
+{
+  private static final String SOAP11_FAULT = "<?xml version='1.0' encoding='UTF-8'?>" +
+                                             "<S11:Envelope xmlns:S11='http://schemas.xmlsoap.org/soap/envelope/'>" +
+                                             "<S11:Body>" +
+                                             "<S11:Fault>" +
+                                             "<faultcode>S11:Client</faultcode>" +
+                                             "<faultstring>Message does not conform</faultstring>" +
+                                             "<faultactor>urn:example:ap</faultactor>" +
+                                             "<detail><myns:reason xmlns:myns='urn:example'>bad payload</myns:reason></detail>" +
+                                             "</S11:Fault>" +
+                                             "</S11:Body>" +
+                                             "</S11:Envelope>";
+
+  private static final String SOAP12_FAULT = "<?xml version='1.0' encoding='UTF-8'?>" +
+                                             "<env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'>" +
+                                             "<env:Body>" +
+                                             "<env:Fault>" +
+                                             "<env:Code>" +
+                                             "<env:Value>env:Sender</env:Value>" +
+                                             "<env:Subcode><env:Value xmlns:m='urn:example:subcodes'>m:MessageTimeout</env:Value></env:Subcode>" +
+                                             "</env:Code>" +
+                                             "<env:Reason><env:Text xml:lang='en'>Sender timeout</env:Text></env:Reason>" +
+                                             "<env:Role>urn:example:role</env:Role>" +
+                                             "<env:Detail><e:cause xmlns:e='urn:example'>expired</e:cause></env:Detail>" +
+                                             "</env:Fault>" +
+                                             "</env:Body>" +
+                                             "</env:Envelope>";
+
+  private static final String SOAP12_RECEIPT_LIKE = "<?xml version='1.0' encoding='UTF-8'?>" +
+                                                    "<env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'>" +
+                                                    "<env:Header/>" +
+                                                    "<env:Body/>" +
+                                                    "</env:Envelope>";
+
+  private static final String HTML_ERROR_PAGE = "<html><head><title>502 Bad Gateway</title></head>" +
+                                                "<body><center><h1>502 Bad Gateway</h1></center></body></html>";
+
+  @Test
+  public void testDetectSoap11Fault ()
+  {
+    final Document aDoc = DOMReader.readXMLDOM (SOAP11_FAULT);
+    assertNotNull (aDoc);
+    assertNotNull (AS4SoapFault.getSoapFaultElementOrNull (aDoc));
+
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (aDoc);
+    assertNotNull (aFault);
+    assertSame (ESoapVersion.SOAP_11, aFault.getSoapVersion ());
+    assertTrue (aFault.hasFaultCode ());
+    assertEquals (ESoapVersion.SOAP_11.getNamespaceURI (), aFault.getFaultCode ().getNamespaceURI ());
+    assertEquals ("Client", aFault.getFaultCode ().getLocalPart ());
+    assertNull (aFault.getFaultSubcode ());
+    assertEquals ("Message does not conform", aFault.getFaultReason ());
+    assertEquals ("urn:example:ap", aFault.getFaultActorRole ());
+    assertNotNull (aFault.getDetailElement ());
+    assertEquals ("detail", aFault.getDetailElement ().getLocalName ());
+    assertTrue (aFault.getRawXML ().contains ("faultcode"));
+    assertSame (EAS4FaultDisposition.PERMANENT, aFault.getDisposition ());
+  }
+
+  @Test
+  public void testDetectSoap12FaultWithSubcode ()
+  {
+    final Document aDoc = DOMReader.readXMLDOM (SOAP12_FAULT);
+    assertNotNull (aDoc);
+    assertNotNull (AS4SoapFault.getSoapFaultElementOrNull (aDoc));
+
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (aDoc);
+    assertNotNull (aFault);
+    assertSame (ESoapVersion.SOAP_12, aFault.getSoapVersion ());
+    assertTrue (aFault.hasFaultCode ());
+    assertEquals (ESoapVersion.SOAP_12.getNamespaceURI (), aFault.getFaultCode ().getNamespaceURI ());
+    assertEquals ("Sender", aFault.getFaultCode ().getLocalPart ());
+    assertNotNull (aFault.getFaultSubcode ());
+    assertEquals ("urn:example:subcodes", aFault.getFaultSubcode ().getNamespaceURI ());
+    assertEquals ("MessageTimeout", aFault.getFaultSubcode ().getLocalPart ());
+    assertEquals ("Sender timeout", aFault.getFaultReason ());
+    assertEquals ("urn:example:role", aFault.getFaultActorRole ());
+    assertNotNull (aFault.getDetailElement ());
+    assertEquals ("Detail", aFault.getDetailElement ().getLocalName ());
+    assertSame (EAS4FaultDisposition.PERMANENT, aFault.getDisposition ());
+  }
+
+  @Test
+  public void testDetectSoap11FaultInSoap12Context ()
+  {
+    // A SOAP 1.1 fault must be detected even if the conversation uses SOAP 1.2 - the detection is
+    // solely based on the document content
+    final Document aDoc = DOMReader.readXMLDOM (SOAP11_FAULT);
+    assertNotNull (aDoc);
+
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (aDoc);
+    assertNotNull (aFault);
+    // The fault carries its own version, not the conversation one
+    assertSame (ESoapVersion.SOAP_11, aFault.getSoapVersion ());
+  }
+
+  @Test
+  public void testNonFaultSoapDocument ()
+  {
+    final Document aDoc = DOMReader.readXMLDOM (SOAP12_RECEIPT_LIKE);
+    assertNotNull (aDoc);
+    assertNull (AS4SoapFault.getSoapFaultElementOrNull (aDoc));
+    assertNull (AS4SoapFault.createOrNull (aDoc));
+  }
+
+  @Test
+  public void testHtmlErrorPage ()
+  {
+    // Even if the HTML can be parsed as XML, it's not in a SOAP namespace
+    final Document aDoc = DOMReader.readXMLDOM (HTML_ERROR_PAGE);
+    assertNull (AS4SoapFault.createOrNull (aDoc));
+    // And a null document must be handled gracefully as well
+    assertNull (AS4SoapFault.getSoapFaultElementOrNull (null));
+    assertNull (AS4SoapFault.createOrNull (null));
+  }
+
+  @Test
+  public void testExplicitRawXML ()
+  {
+    final Document aDoc = DOMReader.readXMLDOM (SOAP11_FAULT);
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (aDoc, SOAP11_FAULT);
+    assertNotNull (aFault);
+    assertEquals (SOAP11_FAULT, aFault.getRawXML ());
+  }
+
+  @Test
+  public void testDispositionMapping ()
+  {
+    // SOAP 1.1 fault codes
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap11Fault ("S11:Client").getDisposition ());
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap11Fault ("S11:Client.Authentication").getDisposition ());
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap11Fault ("S11:VersionMismatch").getDisposition ());
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap11Fault ("S11:MustUnderstand").getDisposition ());
+    assertSame (EAS4FaultDisposition.TRANSIENT, _createSoap11Fault ("S11:Server").getDisposition ());
+
+    // SOAP 1.2 fault codes
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap12Fault ("env:Sender").getDisposition ());
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap12Fault ("env:VersionMismatch").getDisposition ());
+    assertSame (EAS4FaultDisposition.PERMANENT, _createSoap12Fault ("env:MustUnderstand").getDisposition ());
+    assertSame (EAS4FaultDisposition.TRANSIENT, _createSoap12Fault ("env:Receiver").getDisposition ());
+
+    // Unknown fault codes are transient
+    assertSame (EAS4FaultDisposition.TRANSIENT, _createSoap12Fault ("env:DataEncodingUnknown").getDisposition ());
+    assertSame (EAS4FaultDisposition.TRANSIENT, _createSoap11Fault ("S11:Whatever").getDisposition ());
+
+    // Absent fault code is transient
+    final Document aDoc = DOMReader.readXMLDOM ("<S11:Envelope xmlns:S11='http://schemas.xmlsoap.org/soap/envelope/'>" +
+                                                "<S11:Body><S11:Fault><faultstring>x</faultstring></S11:Fault></S11:Body>" +
+                                                "</S11:Envelope>");
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (aDoc);
+    assertNotNull (aFault);
+    assertNull (aFault.getFaultCode ());
+    assertSame (EAS4FaultDisposition.TRANSIENT, aFault.getDisposition ());
+  }
+
+  private static AS4SoapFault _createSoap11Fault (final String sFaultCode)
+  {
+    final String sXML = "<S11:Envelope xmlns:S11='http://schemas.xmlsoap.org/soap/envelope/'>" +
+                        "<S11:Body>" +
+                        "<S11:Fault>" +
+                        "<faultcode>" +
+                        sFaultCode +
+                        "</faultcode>" +
+                        "<faultstring>test</faultstring>" +
+                        "</S11:Fault>" +
+                        "</S11:Body>" +
+                        "</S11:Envelope>";
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (DOMReader.readXMLDOM (sXML));
+    assertNotNull (aFault);
+    return aFault;
+  }
+
+  private static AS4SoapFault _createSoap12Fault (final String sFaultCodeValue)
+  {
+    final String sXML = "<env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'>" +
+                        "<env:Body>" +
+                        "<env:Fault>" +
+                        "<env:Code><env:Value>" +
+                        sFaultCodeValue +
+                        "</env:Value></env:Code>" +
+                        "<env:Reason><env:Text xml:lang='en'>test</env:Text></env:Reason>" +
+                        "</env:Fault>" +
+                        "</env:Body>" +
+                        "</env:Envelope>";
+    final AS4SoapFault aFault = AS4SoapFault.createOrNull (DOMReader.readXMLDOM (sXML));
+    assertNotNull (aFault);
+    return aFault;
+  }
+}

--- a/phase4-lib/src/test/java/com/helger/phase4/model/soapfault/EAS4FaultDispositionTest.java
+++ b/phase4-lib/src/test/java/com/helger/phase4/model/soapfault/EAS4FaultDispositionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.model.soapfault;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.helger.base.string.StringHelper;
+
+/**
+ * Test class for class {@link EAS4FaultDisposition}.
+ *
+ * @author Philip Helger
+ */
+public final class EAS4FaultDispositionTest
+{
+  @Test
+  public void testBasic ()
+  {
+    for (final EAS4FaultDisposition e : EAS4FaultDisposition.values ())
+    {
+      assertTrue (StringHelper.isNotEmpty (e.getID ()));
+      assertSame (e, EAS4FaultDisposition.getFromIDOrNull (e.getID ()));
+    }
+    assertNull (EAS4FaultDisposition.getFromIDOrNull ("bla"));
+    assertNull (EAS4FaultDisposition.getFromIDOrNull (null));
+
+    assertTrue (EAS4FaultDisposition.PERMANENT.isPermanent ());
+    assertFalse (EAS4FaultDisposition.PERMANENT.isTransient ());
+    assertTrue (EAS4FaultDisposition.TRANSIENT.isTransient ());
+    assertFalse (EAS4FaultDisposition.TRANSIENT.isPermanent ());
+  }
+}

--- a/phase4-test/src/test/java/com/helger/phase4/client/AS4ClientUserMessageSoapFaultTest.java
+++ b/phase4-test/src/test/java/com/helger/phase4/client/AS4ClientUserMessageSoapFaultTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import com.helger.base.concurrent.ThreadHelper;
+import com.helger.base.state.EContinue;
+import com.helger.base.string.StringHelper;
+import com.helger.base.url.URLHelper;
+import com.helger.base.wrapper.Wrapper;
+import com.helger.mime.CMimeType;
+import com.helger.mime.IMimeType;
+import com.helger.phase4.AS4TestConstants;
+import com.helger.phase4.CAS4;
+import com.helger.phase4.ScopedAS4Configuration;
+import com.helger.phase4.attachment.AS4OutgoingAttachment;
+import com.helger.phase4.incoming.mgr.AS4ProfileSelector;
+import com.helger.phase4.logging.Phase4LoggerFactory;
+import com.helger.phase4.messaging.http.HttpRetrySettings;
+import com.helger.phase4.model.ESoapVersion;
+import com.helger.phase4.model.message.MessageHelperMethods;
+import com.helger.phase4.model.soapfault.AS4SoapFault;
+import com.helger.phase4.model.soapfault.EAS4FaultDisposition;
+import com.helger.phase4.sender.AbstractAS4UserMessageBuilderMIMEPayload;
+import com.helger.phase4.sender.EAS4UserMessageSendResult;
+import com.helger.phase4.server.AS4JettyRunner;
+import com.helger.phase4.server.MockJettySetup;
+import com.helger.phase4.test.profile.AS4TestProfileRegistarSPI;
+import com.helger.phase4.util.AS4ResourceHelper;
+import com.helger.typeconvert.collection.IStringMap;
+import com.helger.typeconvert.collection.StringMap;
+import com.helger.url.URLBuilder;
+import com.helger.xservlet.requesttrack.RequestTrackerSettings;
+
+/**
+ * Test class for receiving plain SOAP Fault responses to an outgoing AS4 UserMessage. Uses the
+ * {@link MockAS4Servlet} to produce arbitrary fault responses.
+ *
+ * @author Philip Helger
+ */
+public final class AS4ClientUserMessageSoapFaultTest
+{
+  private static final class MockAS4Builder extends AbstractAS4UserMessageBuilderMIMEPayload <MockAS4Builder>
+  {}
+
+  private static final Logger LOGGER = Phase4LoggerFactory.getLogger (AS4ClientUserMessageSoapFaultTest.class);
+
+  private static final String SOAP12_FAULT_SENDER = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                                                    "<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n" +
+                                                    " <env:Body>\n" +
+                                                    "  <env:Fault>\n" +
+                                                    "   <env:Code>\n" +
+                                                    "    <env:Value>env:Sender</env:Value>\n" +
+                                                    "   </env:Code>\n" +
+                                                    "   <env:Reason>\n" +
+                                                    "    <env:Text xml:lang=\"en\">Signing certificate has been revoked</env:Text>\n" +
+                                                    "   </env:Reason>\n" +
+                                                    "  </env:Fault>\n" +
+                                                    " </env:Body>\n" +
+                                                    "</env:Envelope>";
+
+  private static final String SOAP12_FAULT_RECEIVER = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                                                      "<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n" +
+                                                      " <env:Body>\n" +
+                                                      "  <env:Fault>\n" +
+                                                      "   <env:Code>\n" +
+                                                      "    <env:Value>env:Receiver</env:Value>\n" +
+                                                      "   </env:Code>\n" +
+                                                      "   <env:Reason>\n" +
+                                                      "    <env:Text xml:lang=\"en\">Database temporarily unavailable</env:Text>\n" +
+                                                      "   </env:Reason>\n" +
+                                                      "  </env:Fault>\n" +
+                                                      " </env:Body>\n" +
+                                                      "</env:Envelope>";
+
+  private static final String SOAP11_FAULT_CLIENT = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                                                    "<S11:Envelope xmlns:S11=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+                                                    " <S11:Body>\n" +
+                                                    "  <S11:Fault>\n" +
+                                                    "   <faultcode>S11:Client</faultcode>\n" +
+                                                    "   <faultstring>Message does not conform</faultstring>\n" +
+                                                    "  </S11:Fault>\n" +
+                                                    " </S11:Body>\n" +
+                                                    "</S11:Envelope>";
+
+  private static final String HTML_ERROR_PAGE = "<html><head><title>502 Bad Gateway</title></head>" +
+                                                "<body><center><h1>502 Bad Gateway</h1></center></body></html>";
+
+  private static AS4JettyRunner s_aJetty;
+  private static AS4ResourceHelper s_aResHelper;
+
+  @BeforeClass
+  public static void startServer () throws Exception
+  {
+    LOGGER.info ("MockJettySetup - starting");
+    final int nPort = URLHelper.getAsURL (MockJettySetup.getServerAddressFromSettings ()).getPort ();
+    s_aJetty = new AS4JettyRunner ();
+    s_aJetty.setWebXmlResource (s_aJetty.getResourceFactory ()
+                                        .newResource (s_aJetty.getResourceBase ().getName () + "/WEB-INF/web-mock.xml")
+                                        .getName ());
+    s_aJetty.setPort (nPort).setStopPort (nPort + 1000).setAllowAnnotationBasedConfig (false);
+    s_aJetty.startServer ();
+
+    RequestTrackerSettings.setLongRunningRequestsCheckEnabled (false);
+    RequestTrackerSettings.setParallelRunningRequestsCheckEnabled (false);
+    s_aResHelper = new AS4ResourceHelper ();
+
+    AS4ProfileSelector.setCustomDefaultAS4ProfileID (AS4TestProfileRegistarSPI.AS4_PROFILE_ID_MAY_SIGN_MAY_CRYPT);
+
+    LOGGER.info ("MockJettySetup - started");
+  }
+
+  @AfterClass
+  public static void shutDownServer () throws Exception
+  {
+    LOGGER.info ("MockJettySetup - stopping");
+
+    if (s_aResHelper != null)
+      s_aResHelper.close ();
+    if (s_aJetty != null)
+    {
+      s_aJetty.shutDownServer ();
+      // Wait a little until shutdown happened
+      ThreadHelper.sleep (500);
+    }
+    s_aJetty = null;
+    LOGGER.info ("MockJettySetup - stopped");
+  }
+
+  @NonNull
+  private static MockAS4Builder _createBuilder ()
+  {
+    return new MockAS4Builder ().as4ProfileID (AS4TestProfileRegistarSPI.AS4_PROFILE_ID_MAY_SIGN_MAY_CRYPT)
+                                .action ("AnAction")
+                                .service ("MyServiceType", "OrderPaper")
+                                .conversationID (MessageHelperMethods.createRandomConversationID ())
+                                .agreementRef ("bla")
+                                .fromRole (CAS4.DEFAULT_ROLE)
+                                .fromPartyID ("MyPartyIDforSending")
+                                .toRole (CAS4.DEFAULT_ROLE)
+                                .toPartyID ("MyPartyIDforReceving")
+                                .addEbmsProperties (AS4TestConstants.getEBMSProperties ())
+                                .payload (AS4OutgoingAttachment.builder ()
+                                                               .data ("<root xmlns='urn:any'/>".getBytes (StandardCharsets.UTF_8))
+                                                               .mimeTypeXML ()
+                                                               .build ());
+  }
+
+  @NonNull
+  private static String _buildURL (final String sContent, final int nStatusCode, final IMimeType aMimeType)
+  {
+    return URLBuilder.of (MockJettySetup.getServerAddressFromSettings ())
+                     .addParam (MockAS4Servlet.CONTENT, sContent)
+                     .addParam (MockAS4Servlet.STATUSCODE, nStatusCode)
+                     .addParam (MockAS4Servlet.MIMETYPE, aMimeType.getAsString ())
+                     .build ()
+                     .getAsString ();
+  }
+
+  @Test
+  public void testSoap12PermanentFaultWithHttp500 ()
+  {
+    final Wrapper <AS4SoapFault> aFaultKeeper = new Wrapper <> ();
+    final Wrapper <String> aMessageIDKeeper = new Wrapper <> ();
+
+    final EAS4UserMessageSendResult eResult = _createBuilder ().endpointURL (_buildURL (SOAP12_FAULT_SENDER,
+                                                                                        500,
+                                                                                        ESoapVersion.SOAP_12.getMimeType ()))
+                                                               .soapFaultConsumer ((sSentMessageID,
+                                                                                    aSoapFault,
+                                                                                    aClientSentMessage) -> {
+                                                                 aFaultKeeper.set (aSoapFault);
+                                                                 aMessageIDKeeper.set (sSentMessageID);
+                                                                 assertNotNull (aClientSentMessage);
+                                                               })
+                                                               .sendMessageAndCheckForReceipt ();
+    assertEquals (EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED, eResult);
+
+    final AS4SoapFault aSoapFault = aFaultKeeper.get ();
+    assertNotNull (aSoapFault);
+    assertSame (ESoapVersion.SOAP_12, aSoapFault.getSoapVersion ());
+    assertTrue (aSoapFault.hasFaultCode ());
+    assertEquals (ESoapVersion.SOAP_12.getNamespaceURI (), aSoapFault.getFaultCode ().getNamespaceURI ());
+    assertEquals ("Sender", aSoapFault.getFaultCode ().getLocalPart ());
+    assertEquals ("Signing certificate has been revoked", aSoapFault.getFaultReason ());
+    assertSame (EAS4FaultDisposition.PERMANENT, aSoapFault.getDisposition ());
+    assertTrue (StringHelper.isNotEmpty (aMessageIDKeeper.get ()));
+  }
+
+  @Test
+  public void testSoap11FaultWithHttp500InSoap12Conversation ()
+  {
+    // The client sends SOAP 1.2, but the fault comes back as SOAP 1.1 - it must still be detected
+    final Wrapper <AS4SoapFault> aFaultKeeper = new Wrapper <> ();
+
+    final EAS4UserMessageSendResult eResult = _createBuilder ().endpointURL (_buildURL (SOAP11_FAULT_CLIENT,
+                                                                                        500,
+                                                                                        ESoapVersion.SOAP_11.getMimeType ()))
+                                                               .soapFaultConsumer ((sSentMessageID,
+                                                                                    aSoapFault,
+                                                                                    aClientSentMessage) -> aFaultKeeper.set (aSoapFault))
+                                                               .sendMessageAndCheckForReceipt ();
+    assertEquals (EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED, eResult);
+
+    final AS4SoapFault aSoapFault = aFaultKeeper.get ();
+    assertNotNull (aSoapFault);
+    // The fault carries its own SOAP version, not the conversation one
+    assertSame (ESoapVersion.SOAP_11, aSoapFault.getSoapVersion ());
+    assertTrue (aSoapFault.hasFaultCode ());
+    assertEquals ("Client", aSoapFault.getFaultCode ().getLocalPart ());
+    assertEquals ("Message does not conform", aSoapFault.getFaultReason ());
+    assertSame (EAS4FaultDisposition.PERMANENT, aSoapFault.getDisposition ());
+  }
+
+  @Test
+  public void testSoap12TransientFaultWithHttp200 ()
+  {
+    // Non-conforming peers may return a fault with HTTP 200 - it must still be detected
+    final Wrapper <AS4SoapFault> aFaultKeeper = new Wrapper <> ();
+
+    final EAS4UserMessageSendResult eResult = _createBuilder ().endpointURL (_buildURL (SOAP12_FAULT_RECEIVER,
+                                                                                        200,
+                                                                                        ESoapVersion.SOAP_12.getMimeType ()))
+                                                               .soapFaultConsumer ((sSentMessageID,
+                                                                                    aSoapFault,
+                                                                                    aClientSentMessage) -> aFaultKeeper.set (aSoapFault))
+                                                               .sendMessageAndCheckForReceipt ();
+    assertEquals (EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED, eResult);
+
+    final AS4SoapFault aSoapFault = aFaultKeeper.get ();
+    assertNotNull (aSoapFault);
+    assertEquals ("Receiver", aSoapFault.getFaultCode ().getLocalPart ());
+    assertSame (EAS4FaultDisposition.TRANSIENT, aSoapFault.getDisposition ());
+  }
+
+  @Test
+  public void testHtmlErrorPageWithHttp502 ()
+  {
+    // An HTML proxy error page is not a SOAP Fault
+    final Wrapper <AS4SoapFault> aFaultKeeper = new Wrapper <> ();
+
+    final EAS4UserMessageSendResult eResult = _createBuilder ().endpointURL (_buildURL (HTML_ERROR_PAGE,
+                                                                                        502,
+                                                                                        CMimeType.TEXT_HTML))
+                                                               .soapFaultConsumer ((sSentMessageID,
+                                                                                    aSoapFault,
+                                                                                    aClientSentMessage) -> aFaultKeeper.set (aSoapFault))
+                                                               .sendMessageAndCheckForReceipt ();
+    assertEquals (EAS4UserMessageSendResult.NO_SIGNAL_MESSAGE_RECEIVED, eResult);
+    assertNull (aFaultKeeper.get ());
+  }
+
+  @Test
+  public void testPermanentFaultStopsRetriesInLegacyMode ()
+  {
+    // If "accept all status codes" is disabled, a non-2xx response leads to an IOException that is
+    // normally retried. A permanent SOAP Fault must stop all retries immediately.
+    final IStringMap aSettings = new StringMap ();
+    aSettings.putIn ("phase4.http.response.accept.allstatuscodes", false);
+    try (final ScopedAS4Configuration aSC = ScopedAS4Configuration.create (aSettings))
+    {
+      final Wrapper <AS4SoapFault> aFaultKeeper = new Wrapper <> ();
+      final AtomicInteger aRetryCount = new AtomicInteger (0);
+
+      final EAS4UserMessageSendResult eResult = _createBuilder ().endpointURL (_buildURL (SOAP12_FAULT_SENDER,
+                                                                                          500,
+                                                                                          ESoapVersion.SOAP_12.getMimeType ()))
+                                                                 .httpRetrySettings (new HttpRetrySettings ().setMaxRetries (2)
+                                                                                                             .setDurationBeforeRetry (Duration.ofMillis (50)))
+                                                                 .retryCallback ((sMessageID,
+                                                                                  sURL,
+                                                                                  nTry,
+                                                                                  nMaxTries,
+                                                                                  nRetryIntervalMS,
+                                                                                  ex) -> {
+                                                                   aRetryCount.incrementAndGet ();
+                                                                   return EContinue.CONTINUE;
+                                                                 })
+                                                                 .soapFaultConsumer ((sSentMessageID,
+                                                                                      aSoapFault,
+                                                                                      aClientSentMessage) -> aFaultKeeper.set (aSoapFault))
+                                                                 .sendMessageAndCheckForReceipt ();
+      assertEquals (EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED, eResult);
+
+      final AS4SoapFault aSoapFault = aFaultKeeper.get ();
+      assertNotNull (aSoapFault);
+      assertSame (EAS4FaultDisposition.PERMANENT, aSoapFault.getDisposition ());
+      // The permanent fault must have stopped all retries
+      assertEquals (0, aRetryCount.intValue ());
+    }
+  }
+
+  @Test
+  public void testTransientFaultRetriesInLegacyMode ()
+  {
+    // If "accept all status codes" is disabled, a transient SOAP Fault must keep the normal retry
+    // behaviour, but must still be surfaced after all retries are exhausted
+    final IStringMap aSettings = new StringMap ();
+    aSettings.putIn ("phase4.http.response.accept.allstatuscodes", false);
+    try (final ScopedAS4Configuration aSC = ScopedAS4Configuration.create (aSettings))
+    {
+      final Wrapper <AS4SoapFault> aFaultKeeper = new Wrapper <> ();
+      final AtomicInteger aRetryCount = new AtomicInteger (0);
+
+      final EAS4UserMessageSendResult eResult = _createBuilder ().endpointURL (_buildURL (SOAP12_FAULT_RECEIVER,
+                                                                                          500,
+                                                                                          ESoapVersion.SOAP_12.getMimeType ()))
+                                                                 .httpRetrySettings (new HttpRetrySettings ().setMaxRetries (2)
+                                                                                                             .setDurationBeforeRetry (Duration.ofMillis (50)))
+                                                                 .retryCallback ((sMessageID,
+                                                                                  sURL,
+                                                                                  nTry,
+                                                                                  nMaxTries,
+                                                                                  nRetryIntervalMS,
+                                                                                  ex) -> {
+                                                                   aRetryCount.incrementAndGet ();
+                                                                   return EContinue.CONTINUE;
+                                                                 })
+                                                                 .soapFaultConsumer ((sSentMessageID,
+                                                                                      aSoapFault,
+                                                                                      aClientSentMessage) -> aFaultKeeper.set (aSoapFault))
+                                                                 .sendMessageAndCheckForReceipt ();
+      assertEquals (EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED, eResult);
+
+      final AS4SoapFault aSoapFault = aFaultKeeper.get ();
+      assertNotNull (aSoapFault);
+      assertSame (EAS4FaultDisposition.TRANSIENT, aSoapFault.getDisposition ());
+      // The transient fault must have used all configured retries
+      assertEquals (2, aRetryCount.intValue ());
+    }
+  }
+}

--- a/phase4-test/src/test/java/com/helger/phase4/client/AS4ClientUserMessageTestWithCrappyReceiver.java
+++ b/phase4-test/src/test/java/com/helger/phase4/client/AS4ClientUserMessageTestWithCrappyReceiver.java
@@ -57,6 +57,9 @@ import jakarta.mail.MessagingException;
 
 public final class AS4ClientUserMessageTestWithCrappyReceiver
 {
+  private static final class MockAS4Builder extends AbstractAS4UserMessageBuilderMIMEPayload <MockAS4Builder>
+  {}
+
   private static final Logger LOGGER = Phase4LoggerFactory.getLogger (AS4ClientUserMessageTestWithCrappyReceiver.class);
 
   private static AS4JettyRunner s_aJetty;
@@ -186,9 +189,6 @@ public final class AS4ClientUserMessageTestWithCrappyReceiver
     LOGGER.info ("Done with MockServlet tests");
   }
 
-  private static final class MockAS4Builder extends AbstractAS4UserMessageBuilderMIMEPayload <MockAS4Builder>
-  {}
-
   @Test
   public void testSendingAnythingAndReceiveCrapViaBuilder ()
   {
@@ -258,6 +258,6 @@ public final class AS4ClientUserMessageTestWithCrappyReceiver
                                                   .getAsString ())
                           .rawResponseConsumer (aResponseConsumer)
                           .sendMessageAndCheckForReceipt ();
-    assertEquals (EAS4UserMessageSendResult.NO_SIGNAL_MESSAGE_RECEIVED, eResult);
+    assertEquals (EAS4UserMessageSendResult.SOAP_FAULT_RECEIVED, eResult);
   }
 }


### PR DESCRIPTION
SOAP Faults may be returned by actors instead of AS4 SignalMessages - they need to be handled properly and the caller should get access to those details.