### PR TITLE
Make Bouncy Castle optional in phase4-lib

### DIFF
--- a/phase4-bdew-client/pom.xml
+++ b/phase4-bdew-client/pom.xml
@@ -86,6 +86,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.helger.commons</groupId>
+      <artifactId>ph-bc</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-jdk18on</artifactId>
       <version>${bctls.version}</version>

--- a/phase4-edelivery2-client/pom.xml
+++ b/phase4-edelivery2-client/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>ph-unittest-support-ext</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.helger.commons</groupId>
+      <artifactId>ph-bc</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/phase4-lib/pom.xml
+++ b/phase4-lib/pom.xml
@@ -63,6 +63,9 @@
     <dependency>
       <groupId>com.helger.commons</groupId>
       <artifactId>ph-bc</artifactId>
+      <!-- Optional for normal AS4 use. Required for the deprecated BC-based OID API and for
+           reflection/AOT tools that eagerly resolve all method descriptors. -->
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.helger.commons</groupId>

--- a/phase4-lib/src/main/java/com/helger/phase4/crypto/ECryptoAlgorithmCrypt.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/crypto/ECryptoAlgorithmCrypt.java
@@ -18,7 +18,6 @@ package com.helger.phase4.crypto;
 
 import org.apache.wss4j.common.WSS4JConstants;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.cms.CMSAlgorithm;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -29,16 +28,19 @@ import com.helger.base.lang.EnumHelper;
  * Enumeration with all message encryption algorithms supported.
  *
  * @author Philip Helger
+ * @apiNote Direct use of this enum, except for the deprecated {@link #getOID()} method, does not
+ *          require Bouncy Castle. Reflection and AOT tools that eagerly resolve all method
+ *          descriptors still require it for binary compatibility with that method.
  */
 public enum ECryptoAlgorithmCrypt implements ICryptoAlgorithmCrypt
 {
-  CRYPT_3DES ("3des", CMSAlgorithm.DES_EDE3_CBC, WSS4JConstants.TRIPLE_DES),
-  AES_128_CBC ("aes128-cbc", CMSAlgorithm.AES128_CBC, WSS4JConstants.AES_128),
-  AES_128_GCM ("aes128-gcm", CMSAlgorithm.AES128_GCM, WSS4JConstants.AES_128_GCM),
-  AES_192_CBC ("aes192-cbc", CMSAlgorithm.AES192_CBC, WSS4JConstants.AES_192),
-  AES_192_GCM ("aes192-gcm", CMSAlgorithm.AES192_GCM, WSS4JConstants.AES_192_GCM),
-  AES_256_CBC ("aes256-cbc", CMSAlgorithm.AES256_CBC, WSS4JConstants.AES_256),
-  AES_256_GCM ("aes256-gcm", CMSAlgorithm.AES256_GCM, WSS4JConstants.AES_256_GCM);
+  CRYPT_3DES ("3des", "1.2.840.113549.3.7", WSS4JConstants.TRIPLE_DES),
+  AES_128_CBC ("aes128-cbc", "2.16.840.1.101.3.4.1.2", WSS4JConstants.AES_128),
+  AES_128_GCM ("aes128-gcm", "2.16.840.1.101.3.4.1.6", WSS4JConstants.AES_128_GCM),
+  AES_192_CBC ("aes192-cbc", "2.16.840.1.101.3.4.1.22", WSS4JConstants.AES_192),
+  AES_192_GCM ("aes192-gcm", "2.16.840.1.101.3.4.1.26", WSS4JConstants.AES_192_GCM),
+  AES_256_CBC ("aes256-cbc", "2.16.840.1.101.3.4.1.42", WSS4JConstants.AES_256),
+  AES_256_GCM ("aes256-gcm", "2.16.840.1.101.3.4.1.46", WSS4JConstants.AES_256_GCM);
 
   /** Default encrypt algorithm */
   public static final ECryptoAlgorithmCrypt ENCRYPTION_ALGORITHM_DEFAULT = AES_128_GCM;
@@ -48,15 +50,16 @@ public enum ECryptoAlgorithmCrypt implements ICryptoAlgorithmCrypt
   public static final ECryptoAlgorithmCrypt ENCRPYTION_ALGORITHM_DEFAULT = ENCRYPTION_ALGORITHM_DEFAULT;
 
   private final String m_sID;
-  private final ASN1ObjectIdentifier m_aOID;
+  private final String m_sOID;
   private final String m_sAlgorithmURI;
+  private volatile ASN1ObjectIdentifier m_aOID;
 
   ECryptoAlgorithmCrypt (@NonNull @Nonempty final String sID,
-                         @NonNull final ASN1ObjectIdentifier aOID,
+                         @NonNull @Nonempty final String sOID,
                          @NonNull @Nonempty final String sAlgorithmURI)
   {
     m_sID = sID;
-    m_aOID = aOID;
+    m_sOID = sOID;
     m_sAlgorithmURI = sAlgorithmURI;
   }
 
@@ -68,9 +71,25 @@ public enum ECryptoAlgorithmCrypt implements ICryptoAlgorithmCrypt
   }
 
   @NonNull
+  @Nonempty
+  public String getOIDString ()
+  {
+    return m_sOID;
+  }
+
+  @NonNull
+  @Deprecated (since = "4.6.0")
   public ASN1ObjectIdentifier getOID ()
   {
-    return m_aOID;
+    ASN1ObjectIdentifier ret = m_aOID;
+    if (ret == null)
+      synchronized (this)
+      {
+        ret = m_aOID;
+        if (ret == null)
+          m_aOID = ret = new ASN1ObjectIdentifier (m_sOID);
+      }
+    return ret;
   }
 
   /**

--- a/phase4-lib/src/main/java/com/helger/phase4/crypto/ICryptoAlgorithmCrypt.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/crypto/ICryptoAlgorithmCrypt.java
@@ -27,6 +27,11 @@ import com.helger.base.id.IHasID;
  *
  * @author Philip Helger
  * @since v1.4.4
+ * @apiNote Implementations that override {@link #getOIDString()} can support direct use without
+ *          Bouncy Castle. This interface nevertheless retains the deprecated {@link #getOID()}
+ *          method for binary compatibility. Reflection and AOT tools that eagerly resolve every
+ *          method descriptor therefore still require Bouncy Castle until that method can be
+ *          removed in a future major release.
  */
 public interface ICryptoAlgorithmCrypt extends IHasID <String>
 {
@@ -38,9 +43,26 @@ public interface ICryptoAlgorithmCrypt extends IHasID <String>
   String getID ();
 
   /**
-   * @return The OID of the algorithm to be used by the Security Provider.
+   * @return The OID of the algorithm in dot-decimal notation.
+   * @implSpec Implementations should override this method to make direct invocation independent
+   *           of Bouncy Castle. The default implementation delegates to {@link #getOID()} for
+   *           binary compatibility with existing implementations.
+   * @since 4.6.0
    */
   @NonNull
+  @Nonempty
+  default String getOIDString ()
+  {
+    return getOID ().getId ();
+  }
+
+  /**
+   * @return The OID of the algorithm to be used by the Security Provider.
+   * @deprecated Use {@link #getOIDString()} instead. This compatibility method requires Bouncy
+   *             Castle to be present at runtime.
+   */
+  @NonNull
+  @Deprecated (since = "4.6.0")
   ASN1ObjectIdentifier getOID ();
 
   /**

--- a/phase4-lib/src/test/java/com/helger/phase4/crypto/ECryptoAlgorithmCryptTest.java
+++ b/phase4-lib/src/test/java/com/helger/phase4/crypto/ECryptoAlgorithmCryptTest.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phase4.crypto;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -32,12 +33,16 @@ import com.helger.base.string.StringHelper;
 public final class ECryptoAlgorithmCryptTest
 {
   @Test
+  @SuppressWarnings ("deprecation")
   public void testBasic ()
   {
     for (final ECryptoAlgorithmCrypt e : ECryptoAlgorithmCrypt.values ())
     {
       assertTrue (StringHelper.isNotEmpty (e.getID ()));
+      assertTrue (StringHelper.isNotEmpty (e.getOIDString ()));
       assertNotNull (e.getOID ());
+      assertEquals (e.getOIDString (), e.getOID ().getId ());
+      assertSame (e.getOID (), e.getOID ());
       assertTrue (StringHelper.isNotEmpty (e.getAlgorithmURI ()));
       assertSame (e, ECryptoAlgorithmCrypt.getFromIDOrNull (e.getID ()));
       assertSame (e, ECryptoAlgorithmCrypt.getFromIDOrDefault (e.getID (), null));

--- a/phase4-lib/src/test/java/com/helger/phase4/crypto/ECryptoAlgorithmCryptWithoutBCProbe.java
+++ b/phase4-lib/src/test/java/com/helger/phase4/crypto/ECryptoAlgorithmCryptWithoutBCProbe.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.crypto;
+
+/** Invoked through an isolated class loader by {@link ECryptoAlgorithmCryptWithoutBCTest}. */
+public final class ECryptoAlgorithmCryptWithoutBCProbe
+{
+  private ECryptoAlgorithmCryptWithoutBCProbe ()
+  {}
+
+  public static String [] getOIDStrings ()
+  {
+    final ECryptoAlgorithmCrypt [] aValues = ECryptoAlgorithmCrypt.values ();
+    final String [] ret = new String [aValues.length];
+    for (int i = 0; i < aValues.length; ++i)
+      ret[i] = aValues[i].getOIDString ();
+    return ret;
+  }
+}

--- a/phase4-lib/src/test/java/com/helger/phase4/crypto/ECryptoAlgorithmCryptWithoutBCTest.java
+++ b/phase4-lib/src/test/java/com/helger/phase4/crypto/ECryptoAlgorithmCryptWithoutBCTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phase4.crypto;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.Test;
+
+/**
+ * Verifies direct enum initialization and provider-neutral OID access without Bouncy Castle. This
+ * deliberately does not reflect over all enum methods because the retained legacy method
+ * descriptor still references a Bouncy Castle type.
+ */
+public final class ECryptoAlgorithmCryptWithoutBCTest
+{
+  private static final String ENUM_CLASS = ECryptoAlgorithmCrypt.class.getName ();
+  private static final String INTERFACE_CLASS = ICryptoAlgorithmCrypt.class.getName ();
+  private static final String PROBE_CLASS = ECryptoAlgorithmCryptWithoutBCProbe.class.getName ();
+
+  @Test
+  public void testDirectEnumUseWithoutBC () throws Exception
+  {
+    final URL [] aURLs = { new File ("target/classes").toURI ().toURL (),
+                          new File ("target/test-classes").toURI ().toURL () };
+    try (final URLClassLoader aCL = new URLClassLoader (aURLs, getClass ().getClassLoader ())
+    {
+      @Override
+      protected Class <?> loadClass (final String sName, final boolean bResolve) throws ClassNotFoundException
+      {
+        if (sName.startsWith ("org.bouncycastle."))
+          throw new ClassNotFoundException ("Bouncy Castle deliberately hidden from test class loader");
+
+        if (sName.equals (ENUM_CLASS) || sName.equals (INTERFACE_CLASS) || sName.equals (PROBE_CLASS))
+          synchronized (getClassLoadingLock (sName))
+          {
+            Class <?> ret = findLoadedClass (sName);
+            if (ret == null)
+              ret = findClass (sName);
+            if (bResolve)
+              resolveClass (ret);
+            return ret;
+          }
+
+        return super.loadClass (sName, bResolve);
+      }
+    })
+    {
+      try
+      {
+        aCL.loadClass ("org.bouncycastle.asn1.ASN1ObjectIdentifier");
+        fail ("Bouncy Castle must not be visible to the isolated class loader");
+      }
+      catch (final ClassNotFoundException ex)
+      {
+        // Expected
+      }
+
+      final Class <?> aProbeClass = Class.forName (PROBE_CLASS, true, aCL);
+      final String [] aActual = (String []) aProbeClass.getMethod ("getOIDStrings").invoke (null);
+      assertArrayEquals (new String [] { "1.2.840.113549.3.7",
+                                        "2.16.840.1.101.3.4.1.2",
+                                        "2.16.840.1.101.3.4.1.6",
+                                        "2.16.840.1.101.3.4.1.22",
+                                        "2.16.840.1.101.3.4.1.26",
+                                        "2.16.840.1.101.3.4.1.42",
+                                        "2.16.840.1.101.3.4.1.46" },
+                         aActual);
+    }
+  }
+}

--- a/phase4-profile-bdew/pom.xml
+++ b/phase4-profile-bdew/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>phase4-lib</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.helger.commons</groupId>
+      <artifactId>ph-bc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
## Summary

This follows the dependency cleanup in #340 by removing the remaining eager Bouncy Castle requirement from the phase4 core path.

- store the seven standard content-encryption OIDs as dot-decimal strings instead of eagerly reading CMSAlgorithm constants
- add the provider-neutral getOIDString API
- retain and deprecate getOID, constructing its ASN1ObjectIdentifier lazily for source and binary compatibility
- mark ph-bc optional in phase4-lib
- declare ph-bc locally in the BDEW production module and in modules whose tests directly use BC

Normal AS4 use and direct calls to ECryptoAlgorithmCrypt.getOIDString can now run without BC. This does not remove BC from the BDEW profile, which directly uses BC APIs.

## Compatibility note

The deprecated getOID method keeps its ASN1ObjectIdentifier return descriptor for binary compatibility. Calling it still requires ph-bc. Reflection or AOT tools that eagerly resolve every method descriptor also still require ph-bc until that legacy method can be removed in a future major release.

## Verification

- isolated classloader test initializes every ECryptoAlgorithmCrypt value and reads every OID with all org.bouncycastle classes hidden
- separate Java 26 Maven consumer compiled and ran with ph-bc and Cryptacular excluded and no Bouncy Castle artifacts present
- seven-module reactor verify: 204 tests, 0 failures/errors, 1 existing skip

This PR changes only the direct phase4/ph-bc edge; the independent WSS4J/Cryptacular path is intentionally unchanged.