### PR TITLE
Declare the EN 16931 rules dependency used by the Peppol client

### DIFF
--- a/phase4-peppol-client/pom.xml
+++ b/phase4-peppol-client/pom.xml
@@ -79,6 +79,11 @@
     </dependency>
     <dependency>
       <groupId>com.helger.phive.rules</groupId>
+      <artifactId>phive-rules-en16931</artifactId>
+      <version>${phive-rules.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.helger.phive.rules</groupId>
       <artifactId>phive-rules-peppol</artifactId>
       <version>${phive-rules.version}</version>
     </dependency>


### PR DESCRIPTION
Closes #387.

`Phase4PeppolValidation` directly imports and initializes `EN16931Validation`, but `phase4-peppol-client` currently obtains that class only through `phive-rules-peppol` 4.5.3. PHIVE 4.5.4 correctly removes the accidental transitive dependency, which exposes the missing declaration.

This adds the direct dependency and preserves existing behavior until the deprecated validation helper is removed.

Verification:

- Current `master` fails to compile with `-Dphive-rules.version=4.5.4-SNAPSHOT` because `EN16931Validation` is absent.
- With this change, `mvn -pl phase4-peppol-client -am -Dphive-rules.version=4.5.4-SNAPSHOT test` passes: 172 tests, 0 failures/errors, 2 existing skips.