### PR TITLE
Exclude unused ph-masterdata from phase4-lib

### DIFF
--- a/phase4-lib/pom.xml
+++ b/phase4-lib/pom.xml
@@ -107,6 +107,12 @@
     <dependency>
       <groupId>com.helger.masterdata</groupId>
       <artifactId>ph-tenancy</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.helger.masterdata</groupId>
+          <artifactId>ph-masterdata</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.helger.schedule</groupId>


### PR DESCRIPTION
Fixes #390.

`phase4-lib` needs `ph-tenancy` for `AbstractBusinessObject` and `IBusinessObject`, but no Phase4 source uses the transitively supplied `ph-masterdata` API. This focused exclusion keeps the required tenancy dependency and avoids adding an unrelated 1,504,207-byte (1.43 MiB) JAR to every downstream runtime.

This is intentionally an exclusion on the Phase4 dependency edge rather than a change to `ph-tenancy`: other direct consumers of `ph-tenancy` may legitimately need its master-data integration.

Validation:

- `mvn -pl phase4-lib -am verify`: 132 tests, 0 failures/errors
- `mvn verify`: all 27 reactor modules successful
- dependency tree no longer contains `com.helger.masterdata:ph-masterdata`
- ReAI full build and real Peppol-enabled application startup verified without the JAR