### PR TITLE
BDEW profile: Body must be empty and body signature is ALWAYS optional

### DIFF
--- a/phase4-lib/src/main/java/com/helger/phase4/incoming/AS4IncomingHandler.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/incoming/AS4IncomingHandler.java
@@ -1072,6 +1072,7 @@ public final class AS4IncomingHandler
           {
             final ErrorList aErrorList = new ErrorList ();
             aValidator.validatePMode (aPMode, aErrorList, EAS4ProfileValidationMode.USER_MESSAGE);
+            aValidator.validateSoapMessage (aSoapDocument, aIncomingState.getSoapVersion(), aErrorList);
             aValidator.validateUserMessage (aEbmsUserMessage, aErrorList);
             aValidator.validateInitiatorIdentity (aEbmsUserMessage,
                                                   aIncomingState.getSigningCertificate (),

--- a/phase4-lib/src/main/java/com/helger/phase4/profile/IAS4ProfileValidator.java
+++ b/phase4-lib/src/main/java/com/helger/phase4/profile/IAS4ProfileValidator.java
@@ -19,6 +19,7 @@ package com.helger.phase4.profile;
 import java.security.cert.X509Certificate;
 import java.util.EnumSet;
 
+import com.helger.phase4.model.ESoapVersion;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -29,6 +30,7 @@ import com.helger.phase4.ebms3header.Ebms3SignalMessage;
 import com.helger.phase4.ebms3header.Ebms3UserMessage;
 import com.helger.phase4.incoming.IAS4IncomingMessageMetadata;
 import com.helger.phase4.model.pmode.IPMode;
+import org.w3c.dom.Document;
 
 /**
  * Generic AS4 profile validator
@@ -137,7 +139,20 @@ public interface IAS4ProfileValidator
   {}
 
   /**
-   * Validation a UserMessage
+   * Validation of a SoapDocument
+   *
+   * @param aSoapDocument
+   *        The SOAP document to be validated. May not be <code>null</code>.
+   * @param eSoapVersion
+   *       The SOAP version of the document to be validated.
+   * @param aErrorList
+   *        The error list to be filled. May not be <code>null</code>.
+   */
+  default void validateSoapMessage (@NonNull final Document aSoapDocument, @NonNull ESoapVersion eSoapVersion, @NonNull final ErrorList aErrorList)
+  {}
+
+  /**
+   * Validation of a UserMessage
    *
    * @param aUserMsg
    *        The message to be validated. May not be <code>null</code>.
@@ -148,7 +163,7 @@ public interface IAS4ProfileValidator
   {}
 
   /**
-   * Validation a SignalMessage
+   * Validation of a SignalMessage
    *
    * @param aSignalMsg
    *        The message to be validated. May not be <code>null</code>.

--- a/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidator.java
+++ b/phase4-profile-bdew/src/main/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidator.java
@@ -17,7 +17,9 @@
 package com.helger.phase4.profile.bdew;
 
 import java.security.cert.X509Certificate;
+import java.util.EnumSet;
 
+import com.helger.xml.XMLHelper;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -63,6 +65,9 @@ import com.helger.phase4.model.pmode.leg.PModeLegProtocol;
 import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
 import com.helger.phase4.profile.IAS4ProfileValidator;
 import com.helger.phase4.wss.EWSSVersion;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 /**
  * Validate certain requirements imposed by the BDEW project.
@@ -519,9 +524,57 @@ public class BDEWCompatibilityValidator implements IAS4ProfileValidator
   }
 
   @Override
+  public void validateSoapMessage(@NonNull Document aSoapDocument, @NonNull ESoapVersion eSoapVersion, @NonNull ErrorList aErrorList)
+  {
+    ValueEnforcer.notNull (aSoapDocument, "SoapDocument");
+    ValueEnforcer.notNull (aErrorList, "SoapVersion");
+    ValueEnforcer.notNull (aErrorList, "ErrorList");
+
+    final Element aEnvelope = aSoapDocument.getDocumentElement ();
+    if (aEnvelope == null)
+    {
+      aErrorList.add (_createError ("SOAP Envelope is missing"));
+      return;
+    }
+
+    Element aBodyElement = XMLHelper.getFirstChildElementOfName (aEnvelope,
+                                                                 eSoapVersion.getNamespaceURI (),
+                                                                 eSoapVersion.getBodyElementName ());
+
+    if (aBodyElement == null)
+    {
+      aErrorList.add (_createError ("SOAP Body is missing"));
+      return;
+    }
+
+    if (!_isSoapBodyEmpty (aBodyElement))
+      aErrorList.add (_createError ("SOAP Body must be empty"));
+  }
+
+  private static boolean _isSoapBodyEmpty (@NonNull final Element aBodyElement)
+  {
+    for (Node aChild = aBodyElement.getFirstChild (); aChild != null; aChild = aChild.getNextSibling ())
+      switch (aChild.getNodeType ())
+      {
+        case Node.ELEMENT_NODE:
+          return false;
+        case Node.TEXT_NODE, Node.CDATA_SECTION_NODE:
+          final String sNodeValue = aChild.getNodeValue ();
+          if (sNodeValue != null && !sNodeValue.trim ().isEmpty ())
+            return false;
+          break;
+        default:
+          // Ignore comments and processing instructions
+          break;
+      }
+    return true;
+  }
+
+  @Override
   public void validateUserMessage (@NonNull final Ebms3UserMessage aUserMsg, @NonNull final ErrorList aErrorList)
   {
     ValueEnforcer.notNull (aUserMsg, "UserMsg");
+    ValueEnforcer.notNull (aErrorList, "ErrorList");
 
     if (aUserMsg.getMessageInfo () == null)
     {
@@ -637,6 +690,7 @@ public class BDEWCompatibilityValidator implements IAS4ProfileValidator
   public void validateSignalMessage (@NonNull final Ebms3SignalMessage aSignalMsg, @NonNull final ErrorList aErrorList)
   {
     ValueEnforcer.notNull (aSignalMsg, "SignalMsg");
+    ValueEnforcer.notNull (aErrorList, "ErrorList");
 
     if (aSignalMsg.getMessageInfo () == null)
     {
@@ -647,5 +701,10 @@ public class BDEWCompatibilityValidator implements IAS4ProfileValidator
       if (StringHelper.isEmpty (aSignalMsg.getMessageInfo ().getMessageId ()))
         aErrorList.add (_createError ("MessageInfo/MessageId is missing"));
     }
+  }
+
+  @Override
+  public @NonNull EnumSet<ESignedPart> getRequiredSignedParts(boolean bMessageHasAttachments) {
+    return EnumSet.of(ESignedPart.EBMS_MESSAGING, ESignedPart.ATTACHMENTS);
   }
 }

--- a/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidatorTest.java
+++ b/phase4-profile-bdew/src/test/java/com/helger/phase4/profile/bdew/BDEWCompatibilityValidatorTest.java
@@ -16,6 +16,7 @@
  */
 package com.helger.phase4.profile.bdew;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.UUID;
 
+import com.helger.xml.serialize.read.DOMReader;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -69,6 +71,7 @@ import com.helger.phase4.model.pmode.leg.PModeLegSecurity;
 import com.helger.phase4.profile.IAS4ProfileValidator.EAS4ProfileValidationMode;
 import com.helger.phase4.wss.EWSSVersion;
 import com.helger.photon.app.mock.PhotonAppWebTestRule;
+import org.w3c.dom.Document;
 
 /**
  * All essentials need to be set and need to be not null since they are getting
@@ -630,6 +633,35 @@ public final class BDEWCompatibilityValidatorTest
 
     VALIDATOR.validatePMode (m_aPMode, m_aErrorList, EAS4ProfileValidationMode.USER_MESSAGE);
     assertTrue (m_aErrorList.isEmpty ());
+  }
+
+  @Test
+  public void testValidateSoapDocumentHasEmptyBody ()
+  {
+    final Document aSoapDoc = DOMReader.readXMLDOM ("""
+                                                            <S12:Envelope xmlns:S12='http://www.w3.org/2003/05/soap-envelope'>
+                                                            <S12:Header/>
+                                                            <S12:Body>   </S12:Body>
+                                                            </S12:Envelope>""");
+    assertNotNull (aSoapDoc);
+
+    VALIDATOR.validateSoapMessage (aSoapDoc, ESoapVersion.SOAP_12, m_aErrorList);
+    assertTrue (m_aErrorList.isEmpty ());
+  }
+
+  @Test
+  public void testValidateSoapDocumentHasPayloadInBody ()
+  {
+    final Document aSoapDoc = DOMReader.readXMLDOM ("""
+                                                            <S12:Envelope xmlns:S12='http://www.w3.org/2003/05/soap-envelope'>
+                                                            <S12:Header/>
+                                                            <S12:Body><payload/></S12:Body>
+                                                            </S12:Envelope>""");
+    assertNotNull (aSoapDoc);
+
+    VALIDATOR.validateSoapMessage (aSoapDoc, ESoapVersion.SOAP_12, m_aErrorList);
+    assertFalse (m_aErrorList.isEmpty ());
+    assertTrue (m_aErrorList.containsAny (x -> x.getErrorText (LOCALE).contains ("SOAP Body must be empty")));
   }
 
   @Test


### PR DESCRIPTION
In BDEW profile the body must always be empty:

<img width="500"  src="https://github.com/user-attachments/assets/bdd76196-6dab-4743-9203-60630fa22d60" />

https://bdew-mako.de/pdf/AS4-Profil_1.1_v14.pdf

When doing Path Switch requests both must be supported: SwA and Simple SOAP:

<img width="500" src="https://github.com/user-attachments/assets/b4a6d68a-b872-4d93-b79b-4b986e90d771" />

https://bdew-mako.de/questions

The signature of the body is always optional ("sollte", nicht "muss"):

<img width="500"  src="https://github.com/user-attachments/assets/4668af63-32d8-4611-bfb3-1a1b7a528705" />

https://www.bdew.de/media/documents/2000_Technischer_FAQ_AS4.pdf

Thus, the profile validator should check wether the body is actually empty and body signature should be optional.

#392 enforces signature with Simple SOAP.